### PR TITLE
feat: Cask for Winboat application

### DIFF
--- a/Casks/winboat.rb
+++ b/Casks/winboat.rb
@@ -51,6 +51,8 @@ cask "winboat" do
       Winboat requires the following dependencies to be installed:
         - Docker (for running Windows containers)
         - FreeRDP (for remote desktop protocol support)
+      You can install FreeRDP from flatpak:
+        flatpak install com.freerdp.FreeRDP
     EOS
   end
 


### PR DESCRIPTION
Add Cask for Winboat to run Windows apps on Linux.