### PR TITLE
Add JetBrains IDE casks

### DIFF
--- a/Casks/clion-linux.rb
+++ b/Casks/clion-linux.rb
@@ -1,0 +1,66 @@
+cask "clion-linux" do
+  arch intel: "",
+       arm:   "-aarch64"
+  os linux: "linux"
+
+  version "2025.2.4,252.27397.114"
+  sha256 x86_64_linux: "72c89e91f6636aa53930288fe02466e5e09a50a3c8b6ed5ad2f69b35ec9bacc5",
+         arm64_linux:  "b89010db5272eb6490a0084bd3247c9de657ffd0d12a827147f2c77a406f85b5"
+
+  url "https://download.jetbrains.com/cpp/CLion-#{version.csv.first}#{arch}.tar.gz"
+  name "CLion"
+  desc "C and C++ IDE"
+  homepage "https://www.jetbrains.com/clion/"
+
+  livecheck do
+    url "https://data.services.jetbrains.com/products/releases?code=CL&latest=true&type=release"
+    strategy :json do |json|
+      json["CL"]&.map do |release|
+        version = release["version"]
+        build = release["build"]
+        next if version.blank? || build.blank?
+
+        "#{version},#{build}"
+      end
+    end
+  end
+
+  auto_updates false
+  conflicts_with cask: "jetbrains-toolbox-linux"
+
+  binary "#{HOMEBREW_PREFIX}/Caskroom/clion-linux/#{version}/clion-#{version.csv.first}/bin/clion"
+  artifact "jetbrains-clion.desktop",
+           target: "#{Dir.home}/.local/share/applications/jetbrains-clion.desktop"
+  artifact "clion-#{version.csv.first}/bin/clion.svg",
+           target: "#{Dir.home}/.local/share/icons/hicolor/scalable/apps/clion.svg"
+
+  preflight do
+    File.write("#{staged_path}/clion-#{version.csv.first}/bin/clion64.vmoptions", "-Dide.no.platform.update=true\n", mode: "a+")
+    FileUtils.mkdir_p("#{Dir.home}/.local/share/applications")
+    FileUtils.mkdir_p("#{Dir.home}/.local/share/icons/hicolor/scalable/apps")
+    File.write("#{staged_path}/jetbrains-clion.desktop", <<~EOS)
+      [Desktop Entry]
+      Version=1.0
+      Name=CLion
+      Comment=A cross-platform C and C++ IDE
+      Exec=#{HOMEBREW_PREFIX}/bin/clion %u
+      Icon=clion
+      Type=Application
+      Categories=Development;IDE;
+      Keywords=jetbrains;ide;c;c++;
+      Terminal=false
+      StartupWMClass=jetbrains-clion
+      StartupNotify=true
+    EOS
+  end
+
+  postflight do
+    system "/usr/bin/xdg-icon-resource", "forceupdate"
+  end
+
+  zap trash: [
+    "#{Dir.home}/.cache/JetBrains/CLion#{version.major_minor}",
+    "#{Dir.home}/.config/JetBrains/CLion#{version.major_minor}",
+    "#{Dir.home}/.local/share/JetBrains/CLion#{version.major_minor}",
+  ]
+end

--- a/Casks/datagrip-linux.rb
+++ b/Casks/datagrip-linux.rb
@@ -1,0 +1,66 @@
+cask "datagrip-linux" do
+  arch intel: "",
+       arm:   "-aarch64"
+  os linux: "linux"
+
+  version "2025.2.4,252.26830.46"
+  sha256 x86_64_linux: "37d0af4ec30b94c71d3507fe35b3b0bdd389903db7e2f1a8ed73353b22718476",
+         arm64_linux:  "7df40778500a599d565ba985d1583f3334903fbb731f53add526b19557208d97"
+
+  url "https://download.jetbrains.com/datagrip/datagrip-#{version.csv.first}#{arch}.tar.gz"
+  name "DataGrip"
+  desc "Databases and SQL IDE"
+  homepage "https://www.jetbrains.com/datagrip/"
+
+  livecheck do
+    url "https://data.services.jetbrains.com/products/releases?code=DG&latest=true&type=release"
+    strategy :json do |json|
+      json["DG"]&.map do |release|
+        version = release["version"]
+        build = release["build"]
+        next if version.blank? || build.blank?
+
+        "#{version},#{build}"
+      end
+    end
+  end
+
+  auto_updates false
+  conflicts_with cask: "jetbrains-toolbox-linux"
+
+  binary "#{HOMEBREW_PREFIX}/Caskroom/datagrip-linux/#{version}/DataGrip-#{version.csv.first}/bin/datagrip"
+  artifact "jetbrains-datagrip.desktop",
+           target: "#{Dir.home}/.local/share/applications/jetbrains-datagrip.desktop"
+  artifact "DataGrip-#{version.csv.first}/bin/datagrip.svg",
+           target: "#{Dir.home}/.local/share/icons/hicolor/scalable/apps/datagrip.svg"
+
+  preflight do
+    File.write("#{staged_path}/DataGrip-#{version.csv.first}/bin/datagrip64.vmoptions", "-Dide.no.platform.update=true\n", mode: "a+")
+    FileUtils.mkdir_p("#{Dir.home}/.local/share/applications")
+    FileUtils.mkdir_p("#{Dir.home}/.local/share/icons/hicolor/scalable/apps")
+    File.write("#{staged_path}/jetbrains-datagrip.desktop", <<~EOS)
+      [Desktop Entry]
+      Version=1.0
+      Name=DataGrip
+      Comment=The IDE for databases and SQL
+      Exec=#{HOMEBREW_PREFIX}/bin/datagrip %u
+      Icon=datagrip
+      Type=Application
+      Categories=Development;IDE;
+      Keywords=jetbrains;ide;database;sql;
+      Terminal=false
+      StartupWMClass=jetbrains-datagrip
+      StartupNotify=true
+    EOS
+  end
+
+  postflight do
+    system "/usr/bin/xdg-icon-resource", "forceupdate"
+  end
+
+  zap trash: [
+    "#{Dir.home}/.cache/JetBrains/DataGrip#{version.major_minor}",
+    "#{Dir.home}/.config/JetBrains/DataGrip#{version.major_minor}",
+    "#{Dir.home}/.local/share/JetBrains/DataGrip#{version.major_minor}",
+  ]
+end

--- a/Casks/dataspell-linux.rb
+++ b/Casks/dataspell-linux.rb
@@ -1,0 +1,66 @@
+cask "dataspell-linux" do
+  arch intel: "",
+       arm:   "-aarch64"
+  os linux: "linux"
+
+  version "2025.2.3,252.27397.129"
+  sha256 x86_64_linux: "1e4bc499da1ce8c63e8a4526159c20ef8a797315dc6d3ab4c8eb109f323faba6",
+         arm64_linux:  "4bebb406617b4179791d4b6560dc50355760773ef37f6ce9f27bd0d1fd638750"
+
+  url "https://download.jetbrains.com/python/dataspell-#{version.csv.first}#{arch}.tar.gz"
+  name "DataSpell"
+  desc "IDE for Professional Data Scientists"
+  homepage "https://www.jetbrains.com/dataspell/"
+
+  livecheck do
+    url "https://data.services.jetbrains.com/products/releases?code=DS&latest=true&type=release"
+    strategy :json do |json|
+      json["DS"]&.map do |release|
+        version = release["version"]
+        build = release["build"]
+        next if version.blank? || build.blank?
+
+        "#{version},#{build}"
+      end
+    end
+  end
+
+  auto_updates false
+  conflicts_with cask: "jetbrains-toolbox-linux"
+
+  binary "#{HOMEBREW_PREFIX}/Caskroom/dataspell-linux/#{version}/dataspell-#{version.csv.first}/bin/dataspell"
+  artifact "jetbrains-dataspell.desktop",
+           target: "#{Dir.home}/.local/share/applications/jetbrains-dataspell.desktop"
+  artifact "dataspell-#{version.csv.first}/bin/dataspell.svg",
+           target: "#{Dir.home}/.local/share/icons/hicolor/scalable/apps/dataspell.svg"
+
+  preflight do
+    File.write("#{staged_path}/dataspell-#{version.csv.first}/bin/dataspell64.vmoptions", "-Dide.no.platform.update=true\n", mode: "a+")
+    FileUtils.mkdir_p("#{Dir.home}/.local/share/applications")
+    FileUtils.mkdir_p("#{Dir.home}/.local/share/icons/hicolor/scalable/apps")
+    File.write("#{staged_path}/jetbrains-dataspell.desktop", <<~EOS)
+      [Desktop Entry]
+      Version=1.0
+      Name=DataSpell
+      Comment=The IDE for data analysis
+      Exec=#{HOMEBREW_PREFIX}/bin/dataspell %u
+      Icon=dataspell
+      Type=Application
+      Categories=Development;IDE;
+      Keywords=jetbrains;ide;python;r;
+      Terminal=false
+      StartupWMClass=jetbrains-dataspell
+      StartupNotify=true
+    EOS
+  end
+
+  postflight do
+    system "/usr/bin/xdg-icon-resource", "forceupdate"
+  end
+
+  zap trash: [
+    "#{Dir.home}/.cache/JetBrains/DataSpell#{version.major_minor}",
+    "#{Dir.home}/.config/JetBrains/DataSpell#{version.major_minor}",
+    "#{Dir.home}/.local/share/JetBrains/DataSpell#{version.major_minor}",
+  ]
+end

--- a/Casks/goland-linux.rb
+++ b/Casks/goland-linux.rb
@@ -1,0 +1,66 @@
+cask "goland-linux" do
+  arch intel: "",
+       arm:   "-aarch64"
+  os linux: "linux"
+
+  version "2025.2.4,252.27397.100"
+  sha256 x86_64_linux: "fb42978d55271e6fa3165b1d010b3e0bacb8cd5c4f4073712332c62f32d2ebab",
+         arm64_linux:  "09e5790b20c5ca952af8c86a6094e83aa250d9eb751d144800ba83701d3512a8"
+
+  url "https://download.jetbrains.com/go/goland-#{version.csv.first}#{arch}.tar.gz"
+  name "GoLand"
+  desc "Go (golang) IDE"
+  homepage "https://www.jetbrains.com/goland/"
+
+  livecheck do
+    url "https://data.services.jetbrains.com/products/releases?code=GO&latest=true&type=release"
+    strategy :json do |json|
+      json["GO"]&.map do |release|
+        version = release["version"]
+        build = release["build"]
+        next if version.blank? || build.blank?
+
+        "#{version},#{build}"
+      end
+    end
+  end
+
+  auto_updates false
+  conflicts_with cask: "jetbrains-toolbox-linux"
+
+  binary "#{HOMEBREW_PREFIX}/Caskroom/goland-linux/#{version}/GoLand-#{version.csv.first}/bin/goland"
+  artifact "jetbrains-goland.desktop",
+           target: "#{Dir.home}/.local/share/applications/jetbrains-goland.desktop"
+  artifact "GoLand-#{version.csv.first}/bin/goland.svg",
+           target: "#{Dir.home}/.local/share/icons/hicolor/scalable/apps/goland.svg"
+
+  preflight do
+    File.write("#{staged_path}/GoLand-#{version.csv.first}/bin/goland64.vmoptions", "-Dide.no.platform.update=true\n", mode: "a+")
+    FileUtils.mkdir_p("#{Dir.home}/.local/share/applications")
+    FileUtils.mkdir_p("#{Dir.home}/.local/share/icons/hicolor/scalable/apps")
+    File.write("#{staged_path}/jetbrains-goland.desktop", <<~EOS)
+      [Desktop Entry]
+      Version=1.0
+      Name=GoLand
+      Comment=An IDE for Go and Web
+      Exec=#{HOMEBREW_PREFIX}/bin/goland %u
+      Icon=goland
+      Type=Application
+      Categories=Development;IDE;
+      Keywords=jetbrains;ide;go;golang;
+      Terminal=false
+      StartupWMClass=jetbrains-goland
+      StartupNotify=true
+    EOS
+  end
+
+  postflight do
+    system "/usr/bin/xdg-icon-resource", "forceupdate"
+  end
+
+  zap trash: [
+    "#{Dir.home}/.cache/JetBrains/GoLand#{version.major_minor}",
+    "#{Dir.home}/.config/JetBrains/GoLand#{version.major_minor}",
+    "#{Dir.home}/.local/share/JetBrains/GoLand#{version.major_minor}",
+  ]
+end

--- a/Casks/intellij-idea-linux.rb
+++ b/Casks/intellij-idea-linux.rb
@@ -1,0 +1,66 @@
+cask "intellij-idea-linux" do
+  arch intel: "",
+       arm:   "-aarch64"
+  os linux: "linux"
+
+  version "2025.2.4,252.27397.103"
+  sha256 x86_64_linux: "4d909f989d7fa0a002f5bc669e002e8ab336ee7091f32756a74549cd8c11f432",
+         arm64_linux:  "f5687e1d0dc416d6f0fb89495d2b4ad4639d4896497db245272d1fe697b1037b"
+
+  url "https://download.jetbrains.com/idea/ideaIU-#{version.csv.first}#{arch}.tar.gz"
+  name "IntelliJ IDEA Ultimate"
+  desc "Java IDE by JetBrains"
+  homepage "https://www.jetbrains.com/idea/"
+
+  livecheck do
+    url "https://data.services.jetbrains.com/products/releases?code=IIU&latest=true&type=release"
+    strategy :json do |json|
+      json["IIU"]&.map do |release|
+        version = release["version"]
+        build = release["build"]
+        next if version.blank? || build.blank?
+
+        "#{version},#{build}"
+      end
+    end
+  end
+
+  auto_updates false
+  conflicts_with cask: "jetbrains-toolbox-linux"
+
+  binary "#{HOMEBREW_PREFIX}/Caskroom/intellij-idea-linux/#{version}/idea-IU-#{version.csv.second}/bin/idea"
+  artifact "jetbrains-idea.desktop",
+           target: "#{Dir.home}/.local/share/applications/jetbrains-idea.desktop"
+  artifact "idea-IU-#{version.csv.second}/bin/idea.svg",
+           target: "#{Dir.home}/.local/share/icons/hicolor/scalable/apps/idea.svg"
+
+  preflight do
+    File.write("#{staged_path}/idea-IU-#{version.csv.second}/bin/idea64.vmoptions", "-Dide.no.platform.update=true\n", mode: "a+")
+    FileUtils.mkdir_p("#{Dir.home}/.local/share/applications")
+    FileUtils.mkdir_p("#{Dir.home}/.local/share/icons/hicolor/scalable/apps")
+    File.write("#{staged_path}/jetbrains-idea.desktop", <<~EOS)
+      [Desktop Entry]
+      Version=1.0
+      Name=Intellij IDEA
+      Comment=The IDE for pro Java and Kotlin development
+      Exec=#{HOMEBREW_PREFIX}/bin/idea %u
+      Icon=idea
+      Type=Application
+      Categories=Development;IDE;
+      Keywords=jetbrains;ide;java;groovy;kotlin;scala;
+      Terminal=false
+      StartupWMClass=jetbrains-idea
+      StartupNotify=true
+    EOS
+  end
+
+  postflight do
+    system "/usr/bin/xdg-icon-resource", "forceupdate"
+  end
+
+  zap trash: [
+    "#{Dir.home}/.cache/JetBrains/IntelliJIdea#{version.major_minor}",
+    "#{Dir.home}/.config/JetBrains/IntelliJIdea#{version.major_minor}",
+    "#{Dir.home}/.local/share/JetBrains/IntelliJIdea#{version.major_minor}",
+  ]
+end

--- a/Casks/phpstorm-linux.rb
+++ b/Casks/phpstorm-linux.rb
@@ -1,0 +1,66 @@
+cask "phpstorm-linux" do
+  arch intel: "",
+       arm:   "-aarch64"
+  os linux: "linux"
+
+  version "2025.2.4,252.27397.112"
+  sha256 x86_64_linux: "ad2413006344762fb46dc47246e983053b08f763df5c0a2ba0f70ede79a76c3d",
+         arm64_linux:  "60638fee7ed81f75bae931b96d540aa80e8753709f138b60a766a6e29771a3da"
+
+  url "https://download.jetbrains.com/webide/PhpStorm-#{version.csv.first}#{arch}.tar.gz"
+  name "PhpStorm"
+  desc "PHP IDE by JetBrains"
+  homepage "https://www.jetbrains.com/phpstorm/"
+
+  livecheck do
+    url "https://data.services.jetbrains.com/products/releases?code=PS&latest=true&type=release"
+    strategy :json do |json|
+      json["PS"]&.map do |release|
+        version = release["version"]
+        build = release["build"]
+        next if version.blank? || build.blank?
+
+        "#{version},#{build}"
+      end
+    end
+  end
+
+  auto_updates false
+  conflicts_with cask: "jetbrains-toolbox-linux"
+
+  binary "#{HOMEBREW_PREFIX}/Caskroom/phpstorm-linux/#{version}/PhpStorm-#{version.csv.second}/bin/phpstorm"
+  artifact "jetbrains-phpstorm.desktop",
+           target: "#{Dir.home}/.local/share/applications/jetbrains-phpstorm.desktop"
+  artifact "PhpStorm-#{version.csv.second}/bin/phpstorm.svg",
+           target: "#{Dir.home}/.local/share/icons/hicolor/scalable/apps/phpstorm.svg"
+
+  preflight do
+    File.write("#{staged_path}/PhpStorm-#{version.csv.second}/bin/phpstorm64.vmoptions", "-Dide.no.platform.update=true\n", mode: "a+")
+    FileUtils.mkdir_p("#{Dir.home}/.local/share/applications")
+    FileUtils.mkdir_p("#{Dir.home}/.local/share/icons/hicolor/scalable/apps")
+    File.write("#{staged_path}/jetbrains-phpstorm.desktop", <<~EOS)
+      [Desktop Entry]
+      Version=1.0
+      Name=PhpStorm
+      Comment=A smart IDE for PHP and Web
+      Exec=#{HOMEBREW_PREFIX}/bin/phpstorm %u
+      Icon=phpstorm
+      Type=Application
+      Categories=Development;IDE;
+      Keywords=jetbrains;ide;php;
+      Terminal=false
+      StartupWMClass=jetbrains-phpstorm
+      StartupNotify=true
+    EOS
+  end
+
+  postflight do
+    system "/usr/bin/xdg-icon-resource", "forceupdate"
+  end
+
+  zap trash: [
+    "#{Dir.home}/.cache/JetBrains/PhpStorm#{version.major_minor}",
+    "#{Dir.home}/.config/JetBrains/PhpStorm#{version.major_minor}",
+    "#{Dir.home}/.local/share/JetBrains/PhpStorm#{version.major_minor}",
+  ]
+end

--- a/Casks/pycharm-linux.rb
+++ b/Casks/pycharm-linux.rb
@@ -1,0 +1,66 @@
+cask "pycharm-linux" do
+  arch intel: "",
+       arm:   "-aarch64"
+  os linux: "linux"
+
+  version "2025.2.4,252.27397.106"
+  sha256 x86_64_linux: "f1613a171ab07ba0e7ccd13cb537af4da8920c89cf4a13c64a3f7ae72e803701",
+         arm64_linux:  "91569e7ba9988af1aa4d9973f52dfa8af8a94f32a53faa8457c7ba17d25f43b3"
+
+  url "https://download.jetbrains.com/python/pycharm-#{version.csv.first}#{arch}.tar.gz"
+  name "PyCharm"
+  desc "IDE for professional Python development"
+  homepage "https://www.jetbrains.com/pycharm/"
+
+  livecheck do
+    url "https://data.services.jetbrains.com/products/releases?code=PCP&latest=true&type=release"
+    strategy :json do |json|
+      json["PCP"]&.map do |release|
+        version = release["version"]
+        build = release["build"]
+        next if version.blank? || build.blank?
+
+        "#{version},#{build}"
+      end
+    end
+  end
+
+  auto_updates false
+  conflicts_with cask: "jetbrains-toolbox-linux"
+
+  binary "#{HOMEBREW_PREFIX}/Caskroom/pycharm-linux/#{version}/pycharm-#{version.csv.first}/bin/pycharm"
+  artifact "jetbrains-pycharm.desktop",
+           target: "#{Dir.home}/.local/share/applications/jetbrains-pycharm.desktop"
+  artifact "pycharm-#{version.csv.first}/bin/pycharm.svg",
+           target: "#{Dir.home}/.local/share/icons/hicolor/scalable/apps/pycharm.svg"
+
+  preflight do
+    File.write("#{staged_path}/pycharm-#{version.csv.first}/bin/pycharm64.vmoptions", "-Dide.no.platform.update=true\n", mode: "a+")
+    FileUtils.mkdir_p("#{Dir.home}/.local/share/applications")
+    FileUtils.mkdir_p("#{Dir.home}/.local/share/icons/hicolor/scalable/apps")
+    File.write("#{staged_path}/jetbrains-pycharm.desktop", <<~EOS)
+      [Desktop Entry]
+      Version=1.0
+      Name=PyCharm
+      Comment=The Only Python IDE you need
+      Exec=#{HOMEBREW_PREFIX}/bin/pycharm %u
+      Icon=pycharm
+      Type=Application
+      Categories=Development;IDE;
+      Keywords=jetbrains;ide;python;
+      Terminal=false
+      StartupWMClass=jetbrains-pycharm
+      StartupNotify=true
+    EOS
+  end
+
+  postflight do
+    system "/usr/bin/xdg-icon-resource", "forceupdate"
+  end
+
+  zap trash: [
+    "#{Dir.home}/.cache/JetBrains/PyCharm#{version.major_minor}",
+    "#{Dir.home}/.config/JetBrains/PyCharm#{version.major_minor}",
+    "#{Dir.home}/.local/share/JetBrains/PyCharm#{version.major_minor}",
+  ]
+end

--- a/Casks/rider-linux.rb
+++ b/Casks/rider-linux.rb
@@ -1,0 +1,66 @@
+cask "rider-linux" do
+  arch intel: "",
+       arm:   "-aarch64"
+  os linux: "linux"
+
+  version "2025.3.0.1,253.28294.112"
+  sha256 x86_64_linux: "9636742a99eb4a14c156a2bcb0dfe8e55906cd240ba2b5c2be7cbc585f1f5593",
+         arm64_linux:  "be4c45dc6aa48f850a0e904aa24a61913363c0beb3723066eddb3cafe4aa71dc"
+
+  url "https://download.jetbrains.com/rider/JetBrains.Rider-#{version.csv.first}#{arch}.tar.gz"
+  name "Rider"
+  desc ".NET IDE"
+  homepage "https://www.jetbrains.com/rider/"
+
+  livecheck do
+    url "https://data.services.jetbrains.com/products/releases?code=RD&latest=true&type=release"
+    strategy :json do |json|
+      json["RD"]&.map do |release|
+        version = release["version"]
+        build = release["build"]
+        next if version.blank? || build.blank?
+
+        "#{version},#{build}"
+      end
+    end
+  end
+
+  auto_updates false
+  conflicts_with cask: "jetbrains-toolbox-linux"
+
+  binary "#{HOMEBREW_PREFIX}/Caskroom/rider-linux/#{version}/JetBrains Rider-#{version.csv.first}/bin/rider"
+  artifact "jetbrains-rider.desktop",
+           target: "#{Dir.home}/.local/share/applications/jetbrains-rider.desktop"
+  artifact "JetBrains Rider-#{version.csv.first}/bin/rider.svg",
+           target: "#{Dir.home}/.local/share/icons/hicolor/scalable/apps/rider.svg"
+
+  preflight do
+    File.write("#{staged_path}/JetBrains Rider-#{version.csv.first}/bin/rider64.vmoptions", "-Dide.no.platform.update=true\n", mode: "a+")
+    FileUtils.mkdir_p("#{Dir.home}/.local/share/applications")
+    FileUtils.mkdir_p("#{Dir.home}/.local/share/icons/hicolor/scalable/apps")
+    File.write("#{staged_path}/jetbrains-rider.desktop", <<~EOS)
+      [Desktop Entry]
+      Version=1.0
+      Name=Rider
+      Comment=All-in-one IDE for .NET and game development
+      Exec=#{HOMEBREW_PREFIX}/bin/rider %u
+      Icon=rider
+      Type=Application
+      Categories=Development;IDE;
+      Keywords=jetbrains;ide;c#;f#;dotnet;.net;
+      Terminal=false
+      StartupWMClass=jetbrains-rider
+      StartupNotify=true
+    EOS
+  end
+
+  postflight do
+    system "/usr/bin/xdg-icon-resource", "forceupdate"
+  end
+
+  zap trash: [
+    "#{Dir.home}/.cache/JetBrains/Rider#{version.major_minor}",
+    "#{Dir.home}/.config/JetBrains/Rider#{version.major_minor}",
+    "#{Dir.home}/.local/share/JetBrains/Rider#{version.major_minor}",
+  ]
+end

--- a/Casks/rubymine-linux.rb
+++ b/Casks/rubymine-linux.rb
@@ -1,0 +1,66 @@
+cask "rubymine-linux" do
+  arch intel: "",
+       arm:   "-aarch64"
+  os linux: "linux"
+
+  version "2025.2.4,252.27397.109"
+  sha256 x86_64_linux: "9249ee0e99e24b3898065c5328f56814fb1a8b53afc192e81e7b70e0982eb116",
+         arm64_linux:  "4071efa011638cf96f50962b4a7cdf1a28bbdc58af0ebc4c96ddfcc44de48621"
+
+  url "https://download.jetbrains.com/ruby/RubyMine-#{version.csv.first}#{arch}.tar.gz"
+  name "RubyMine"
+  desc "Ruby on Rails IDE"
+  homepage "https://www.jetbrains.com/rubymine/"
+
+  livecheck do
+    url "https://data.services.jetbrains.com/products/releases?code=RM&latest=true&type=release"
+    strategy :json do |json|
+      json["RM"]&.map do |release|
+        version = release["version"]
+        build = release["build"]
+        next if version.blank? || build.blank?
+
+        "#{version},#{build}"
+      end
+    end
+  end
+
+  auto_updates false
+  conflicts_with cask: "jetbrains-toolbox-linux"
+
+  binary "#{HOMEBREW_PREFIX}/Caskroom/rubymine-linux/#{version}/RubyMine-#{version.csv.first}/bin/rubymine"
+  artifact "jetbrains-rubymine.desktop",
+           target: "#{Dir.home}/.local/share/applications/jetbrains-rubymine.desktop"
+  artifact "RubyMine-#{version.csv.first}/bin/rubymine.svg",
+           target: "#{Dir.home}/.local/share/icons/hicolor/scalable/apps/rubymine.svg"
+
+  preflight do
+    File.write("#{staged_path}/RubyMine-#{version.csv.first}/bin/rubymine64.vmoptions", "-Dide.no.platform.update=true\n", mode: "a+")
+    FileUtils.mkdir_p("#{Dir.home}/.local/share/applications")
+    FileUtils.mkdir_p("#{Dir.home}/.local/share/icons/hicolor/scalable/apps")
+    File.write("#{staged_path}/jetbrains-rubymine.desktop", <<~EOS)
+      [Desktop Entry]
+      Version=1.0
+      Name=RubyMine
+      Comment=A Ruby and Rails IDE
+      Exec=#{HOMEBREW_PREFIX}/bin/rubymine %u
+      Icon=rubymine
+      Type=Application
+      Categories=Development;IDE;
+      Keywords=jetbrains;ide;ruby;rails;
+      Terminal=false
+      StartupWMClass=jetbrains-rubymine
+      StartupNotify=true
+    EOS
+  end
+
+  postflight do
+    system "/usr/bin/xdg-icon-resource", "forceupdate"
+  end
+
+  zap trash: [
+    "#{Dir.home}/.cache/JetBrains/RubyMine#{version.major_minor}",
+    "#{Dir.home}/.config/JetBrains/RubyMine#{version.major_minor}",
+    "#{Dir.home}/.local/share/JetBrains/RubyMine#{version.major_minor}",
+  ]
+end

--- a/Casks/rustrover-linux.rb
+++ b/Casks/rustrover-linux.rb
@@ -1,0 +1,66 @@
+cask "rustrover-linux" do
+  arch intel: "",
+       arm:   "-aarch64"
+  os linux: "linux"
+
+  version "2025.2.4.1,252.27397.133"
+  sha256 x86_64_linux: "a51a62af4801f7f4caf8586dde0354d06f6bc351660b75feff554e756874cb37",
+         arm64_linux:  "83d868b92b79907dc42d9e4aacc2a2aae3f9838d392c5a7593487bf4cbb8c641"
+
+  url "https://download.jetbrains.com/rustrover/RustRover-#{version.csv.first}#{arch}.tar.gz"
+  name "RustRover"
+  desc "Rust IDE"
+  homepage "https://www.jetbrains.com/rustrover/"
+
+  livecheck do
+    url "https://data.services.jetbrains.com/products/releases?code=RR&latest=true&type=release"
+    strategy :json do |json|
+      json["RR"]&.map do |release|
+        version = release["version"]
+        build = release["build"]
+        next if version.blank? || build.blank?
+
+        "#{version},#{build}"
+      end
+    end
+  end
+
+  auto_updates false
+  conflicts_with cask: "jetbrains-toolbox-linux"
+
+  binary "#{HOMEBREW_PREFIX}/Caskroom/rustrover-linux/#{version}/RustRover-#{version.csv.first}/bin/rustrover"
+  artifact "jetbrains-rustrover.desktop",
+           target: "#{Dir.home}/.local/share/applications/jetbrains-rustrover.desktop"
+  artifact "RustRover-#{version.csv.first}/bin/rustrover.svg",
+           target: "#{Dir.home}/.local/share/icons/hicolor/scalable/apps/rustrover.svg"
+
+  preflight do
+    File.write("#{staged_path}/RustRover-#{version.csv.first}/bin/rustrover64.vmoptions", "-Dide.no.platform.update=true\n", mode: "a+")
+    FileUtils.mkdir_p("#{Dir.home}/.local/share/applications")
+    FileUtils.mkdir_p("#{Dir.home}/.local/share/icons/hicolor/scalable/apps")
+    File.write("#{staged_path}/jetbrains-rustrover.desktop", <<~EOS)
+      [Desktop Entry]
+      Version=1.0
+      Name=RustRover
+      Comment=A powerful IDE for Rust
+      Exec=#{HOMEBREW_PREFIX}/bin/rustrover %u
+      Icon=rustrover
+      Type=Application
+      Categories=Development;IDE;
+      Keywords=jetbrains;ide;rust;
+      Terminal=false
+      StartupWMClass=jetbrains-rustrover
+      StartupNotify=true
+    EOS
+  end
+
+  postflight do
+    system "/usr/bin/xdg-icon-resource", "forceupdate"
+  end
+
+  zap trash: [
+    "#{Dir.home}/.cache/JetBrains/RustRover#{version.major_minor}",
+    "#{Dir.home}/.config/JetBrains/RustRover#{version.major_minor}",
+    "#{Dir.home}/.local/share/JetBrains/RustRover#{version.major_minor}",
+  ]
+end

--- a/Casks/webstorm-linux.rb
+++ b/Casks/webstorm-linux.rb
@@ -1,0 +1,66 @@
+cask "webstorm-linux" do
+  arch intel: "",
+       arm:   "-aarch64"
+  os linux: "linux"
+
+  version "2025.2.4,252.27397.92"
+  sha256 x86_64_linux: "218d0cb6acd1f63c9b2877738af808279796d3d7e13318b54b021c8526d49b86",
+         arm64_linux:  "1a424cb2a6c82b4fd23e087264a91dfce3a8e78d49c8988f461deafa1aa73d37"
+
+  url "https://download.jetbrains.com/webstorm/WebStorm-#{version.csv.first}#{arch}.tar.gz"
+  name "WebStorm"
+  desc "JavaScript IDE"
+  homepage "https://www.jetbrains.com/webstorm/"
+
+  livecheck do
+    url "https://data.services.jetbrains.com/products/releases?code=WS&latest=true&type=release"
+    strategy :json do |json|
+      json["WS"]&.map do |release|
+        version = release["version"]
+        build = release["build"]
+        next if version.blank? || build.blank?
+
+        "#{version},#{build}"
+      end
+    end
+  end
+
+  auto_updates false
+  conflicts_with cask: "jetbrains-toolbox-linux"
+
+  binary "#{HOMEBREW_PREFIX}/Caskroom/webstorm-linux/#{version}/WebStorm-#{version.csv.second}/bin/webstorm"
+  artifact "jetbrains-webstorm.desktop",
+           target: "#{Dir.home}/.local/share/applications/jetbrains-webstorm.desktop"
+  artifact "WebStorm-#{version.csv.second}/bin/webstorm.svg",
+           target: "#{Dir.home}/.local/share/icons/hicolor/scalable/apps/webstorm.svg"
+
+  preflight do
+    File.write("#{staged_path}/WebStorm-#{version.csv.second}/bin/webstorm64.vmoptions", "-Dide.no.platform.update=true\n", mode: "a+")
+    FileUtils.mkdir_p("#{Dir.home}/.local/share/applications")
+    FileUtils.mkdir_p("#{Dir.home}/.local/share/icons/hicolor/scalable/apps")
+    File.write("#{staged_path}/jetbrains-webstorm.desktop", <<~EOS)
+      [Desktop Entry]
+      Version=1.0
+      Name=WebStorm
+      Comment=A JavaScript and TypeScript IDE
+      Exec=#{HOMEBREW_PREFIX}/bin/webstorm %u
+      Icon=webstorm
+      Type=Application
+      Categories=Development;IDE;
+      Keywords=jetbrains;ide;javascript;typescript;
+      Terminal=false
+      StartupWMClass=jetbrains-webstorm
+      StartupNotify=true
+    EOS
+  end
+
+  postflight do
+    system "/usr/bin/xdg-icon-resource", "forceupdate"
+  end
+
+  zap trash: [
+    "#{Dir.home}/.cache/JetBrains/WebStorm#{version.major_minor}",
+    "#{Dir.home}/.config/JetBrains/WebStorm#{version.major_minor}",
+    "#{Dir.home}/.local/share/JetBrains/WebStorm#{version.major_minor}",
+  ]
+end


### PR DESCRIPTION
Adds casks for the 11 main jetbrains IDEs, mirroring the naming and structure of the macos casks in homebrew proper.
Uses the same general deskop files as the ones created by toolbox, with a few tweaks:
- no version numbers in desktop file or app name
- icon is installed instead of direct linked
- search keywords are added (e.g. searching jetbrains will now bring up their IDEs)

These casks are already available for macos, and seemed a good candidate for adding to the ublue tap (I've been using them from my own tap, anyhow). Is there interest in adding them here?