### PR TITLE
fix: ensure Homebrew environment is set up even when already installed

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -19,22 +19,21 @@ jobs:
             echo "Homebrew not found, installing..."
             NONINTERACTIVE=1 /bin/bash -c \
               "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-
-              eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-
-              brew tap --force "${{ github.repository }}"
-
-              {
-                echo "HOMEBREW_PREFIX=$HOMEBREW_PREFIX"
-                echo "HOMEBREW_CELLAR=$HOMEBREW_CELLAR"
-                echo "HOMEBREW_REPOSITORY=$HOMEBREW_REPOSITORY"
-                echo "PATH=$PATH"
-                echo "MANPATH=$MANPATH"
-                echo "INFOPATH=$INFOPATH"
-              } >> "$GITHUB_ENV"
           else
             echo "Homebrew already installed"
           fi
+
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          brew tap --force "${{ github.repository }}"
+
+          {
+            echo "HOMEBREW_PREFIX=$HOMEBREW_PREFIX"
+            echo "HOMEBREW_CELLAR=$HOMEBREW_CELLAR"
+            echo "HOMEBREW_REPOSITORY=$HOMEBREW_REPOSITORY"
+            echo "PATH=$PATH"
+            echo "MANPATH=$MANPATH"
+            echo "INFOPATH=$INFOPATH"
+          } >> "$GITHUB_ENV"
 
       - name: Configure git
         uses: Homebrew/actions/git-user-config@main


### PR DESCRIPTION
## Problem
The bump workflow was failing with `brew: command not found` because the environment setup (shellenv eval and PATH configuration) only ran when Homebrew was being installed, not when it was already present on the runner.

## Solution
Moved the environment setup and tap commands outside the if/else block so they execute regardless of installation status.

## Changes
- Environment variables (PATH, HOMEBREW_PREFIX, etc.) are now always exported to $GITHUB_ENV
- The `brew tap` command now always runs
- This ensures the `brew` command is available in subsequent workflow steps

Fixes the error seen in recent workflow runs where `brew bump` failed with exit code 127 (command not found).