### PR TITLE
fix: only set StartupWMClass on emacs.desktop

### DIFF
--- a/Casks/emacs-app-linux.rb
+++ b/Casks/emacs-app-linux.rb
@@ -165,17 +165,12 @@ cask "emacs-app-linux" do
       desktop_content.gsub!(%r{Exec=/usr/local/bin/emacsclient}, "Exec=#{HOMEBREW_PREFIX}/bin/emacsclient")
       desktop_content.gsub!("Exec=emacsclient", "Exec=#{HOMEBREW_PREFIX}/bin/emacsclient")
 
-      # Fix WMClass to ensure proper window grouping (use hyphen, not dot, to match Emacs binary name)
-      # Replace existing StartupWMClass line or add new one if missing
-      case desktop_content
-      when /^StartupWMClass=/i
+      # Only set StartupWMClass on emacs.desktop so the window matches the correct launcher.
+      # Remove it from other desktop files to prevent them from claiming the Emacs window.
+      if desktop_name == "emacs"
         desktop_content.gsub!(/^StartupWMClass=.*/i, "StartupWMClass=#{emacs_wm_class}")
-      when /^StartupNotify=/i
-        # Insert after StartupNotify line if it exists
-        desktop_content.gsub!(/^(StartupNotify=.*?)$/i, "\\1\nStartupWMClass=#{emacs_wm_class}")
-      when /^Categories=/i
-        # Insert before Categories line if it exists
-        desktop_content.gsub!(/^(Categories=.*?)$/i, "StartupWMClass=#{emacs_wm_class}\n\\1")
+      else
+        desktop_content.gsub!(/^StartupWMClass=.*\n?/i, "")
       end
 
       File.write("#{Dir.home}/.local/share/applications/#{desktop_name}.desktop", desktop_content)

--- a/Casks/emacs-app-linux.rb
+++ b/Casks/emacs-app-linux.rb
@@ -165,10 +165,21 @@ cask "emacs-app-linux" do
       desktop_content.gsub!(%r{Exec=/usr/local/bin/emacsclient}, "Exec=#{HOMEBREW_PREFIX}/bin/emacsclient")
       desktop_content.gsub!("Exec=emacsclient", "Exec=#{HOMEBREW_PREFIX}/bin/emacsclient")
 
-      # Only set StartupWMClass on emacs.desktop so the window matches the correct launcher.
-      # Remove it from other desktop files to prevent them from claiming the Emacs window.
+      # Only set StartupWMClass on emacs.desktop so the window matches the
+      # correct launcher. Remove it from other desktop files to prevent them
+      # from claiming the Emacs window.
       if desktop_name == "emacs"
-        desktop_content.gsub!(/^StartupWMClass=.*/i, "StartupWMClass=#{emacs_wm_class}")
+        if desktop_content.match?(/^StartupWMClass=/i)
+          # Replace any existing StartupWMClass line.
+          desktop_content.gsub!(/^StartupWMClass=.*/i, "StartupWMClass=#{emacs_wm_class}")
+        elsif desktop_content.sub!(/^StartupNotify=.*$/i) { |line| "#{line}\nStartupWMClass=#{emacs_wm_class}" }
+          # Inserted after StartupNotify.
+        elsif desktop_content.sub!(/^Categories=.*$/i) { |line| "StartupWMClass=#{emacs_wm_class}\n#{line}" }
+          # Inserted before Categories.
+        else
+          # Fallback: append at end if neither StartupNotify nor Categories exists.
+          desktop_content << "\nStartupWMClass=#{emacs_wm_class}\n"
+        end
       else
         desktop_content.gsub!(/^StartupWMClass=.*\n?/i, "")
       end


### PR DESCRIPTION
The Emacs PGTK window reports a versioned WM_CLASS (e.g. emacs-30-2). Previously, StartupWMClass was set to this value on all four desktop files, causing GNOME to match the window to the wrong launcher (e.g. emacs-mail.desktop).

Now only emacs.desktop gets StartupWMClass set; the other desktop files have it removed so the window matches the correct launcher.