### PR TITLE
feat(zed): add zed-linux and zed-linux@preview casks

### DIFF
--- a/Casks/zed-linux.rb
+++ b/Casks/zed-linux.rb
@@ -1,0 +1,45 @@
+cask "zed-linux" do
+  version "0.232.2"
+  sha256 "c29bb79ce38e9ccbe40d956d9a02559c0e368916ff272b892bd585e889415f93"
+
+  url "https://github.com/zed-industries/zed/releases/download/v#{version}/zed-linux-x86_64.tar.gz"
+  name "Zed"
+  desc "High-performance, multiplayer code editor"
+  homepage "https://zed.dev/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  binary "zed.app/bin/zed"
+
+  preflight do
+    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
+    FileUtils.mkdir_p "#{xdg_data}/applications"
+    FileUtils.mkdir_p "#{xdg_data}/icons"
+  end
+
+  postflight do
+    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
+    desktop_content = File.read("#{staged_path}/zed.app/share/applications/dev.zed.Zed.desktop")
+    desktop_content.gsub!(/^TryExec=.*/, "TryExec=#{HOMEBREW_PREFIX}/bin/zed")
+    desktop_content.gsub!(/^Exec=zed/, "Exec=#{HOMEBREW_PREFIX}/bin/zed")
+    desktop_content.gsub!(/^Icon=.*/, "Icon=zed")
+    File.write("#{xdg_data}/applications/dev.zed.Zed.desktop", desktop_content)
+    FileUtils.cp("#{staged_path}/zed.app/share/icons/hicolor/512x512/apps/zed.png",
+                 "#{xdg_data}/icons/zed.png")
+  end
+
+  uninstall_postflight do
+    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
+    FileUtils.rm("#{xdg_data}/applications/dev.zed.Zed.desktop")
+    FileUtils.rm("#{xdg_data}/icons/zed.png")
+  end
+
+  zap trash: [
+    "#{ENV.fetch("XDG_CACHE_HOME", "#{Dir.home}/.cache")}/zed",
+    "#{ENV.fetch("XDG_CONFIG_HOME", "#{Dir.home}/.config")}/zed",
+    "#{ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")}/zed",
+  ]
+end

--- a/Casks/zed-linux@preview.rb
+++ b/Casks/zed-linux@preview.rb
@@ -1,0 +1,47 @@
+cask "zed-linux@preview" do
+  version "0.233.1"
+  sha256 "7693529112bb477c9aa3f9e09bd20a9d0ce20c2f606d3aef555f4636a564c2c0"
+
+  url "https://zed.dev/api/releases/preview/#{version}/zed-linux-x86_64.tar.gz"
+  name "Zed Preview"
+  desc "High-performance, multiplayer code editor (preview build)"
+  homepage "https://zed.dev/"
+
+  livecheck do
+    url "https://zed.dev/api/releases/latest?asset=zed-linux-x86_64.tar.gz&preview=1&os=linux&arch=x86_64"
+    strategy :json do |json|
+      json["version"]
+    end
+  end
+
+  binary "zed-preview.app/bin/zed", target: "zed-preview"
+
+  preflight do
+    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
+    FileUtils.mkdir_p "#{xdg_data}/applications"
+    FileUtils.mkdir_p "#{xdg_data}/icons"
+  end
+
+  postflight do
+    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
+    desktop_content = File.read("#{staged_path}/zed-preview.app/share/applications/dev.zed.Zed-Preview.desktop")
+    desktop_content.gsub!(/^TryExec=.*/, "TryExec=#{HOMEBREW_PREFIX}/bin/zed-preview")
+    desktop_content.gsub!(/^Exec=zed/, "Exec=#{HOMEBREW_PREFIX}/bin/zed-preview")
+    desktop_content.gsub!(/^Icon=.*/, "Icon=zed-preview")
+    File.write("#{xdg_data}/applications/dev.zed.Zed-Preview.desktop", desktop_content)
+    FileUtils.cp("#{staged_path}/zed-preview.app/share/icons/hicolor/512x512/apps/zed.png",
+                 "#{xdg_data}/icons/zed-preview.png")
+  end
+
+  uninstall_postflight do
+    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
+    FileUtils.rm("#{xdg_data}/applications/dev.zed.Zed-Preview.desktop")
+    FileUtils.rm("#{xdg_data}/icons/zed-preview.png")
+  end
+
+  zap trash: [
+    "#{ENV.fetch("XDG_CACHE_HOME", "#{Dir.home}/.cache")}/zed",
+    "#{ENV.fetch("XDG_CONFIG_HOME", "#{Dir.home}/.config")}/zed",
+    "#{ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")}/zed",
+  ]
+end


### PR DESCRIPTION
Part of https://github.com/projectbluefin/common/issues/281

Port zed-linux and zed-linux@preview from agammemnon/homebrew-tap, adapted to ublue-os tap standards:
- XDG env vars throughout (XDG_DATA_HOME, XDG_CONFIG_HOME, XDG_CACHE_HOME)
- zed-linux: livecheck uses url :url + strategy :github_latest
- zed-linux@preview: livecheck uses custom JSON strategy against zed.dev API

zed-linux: v0.232.2 (stable, github.com/zed-industries/zed)
zed-linux@preview: v0.233.1 (preview channel, zed.dev/api)