### PR TITLE
feat: add claude-code-linux cask

### DIFF
--- a/Casks/claude-code-linux.rb
+++ b/Casks/claude-code-linux.rb
@@ -1,0 +1,25 @@
+cask "claude-code-linux" do
+  version "2.1.117"
+  sha256 "b7246963d9e32ece439c3e1e7885f53773a4820e90a4d2433ef2a413a055a5fe"
+
+  url "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/#{version}/linux-x64/claude",
+      verified: "storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/"
+  name "Claude Code"
+  desc "Terminal-based AI coding assistant by Anthropic"
+  homepage "https://www.anthropic.com/claude-code"
+
+  livecheck do
+    url "https://registry.npmjs.org/@anthropic-ai/claude-code"
+    regex(/"latest"\s*:\s*"(\d+(?:\.\d+)+)"/i)
+  end
+
+  binary "claude"
+
+  zap trash: [
+    "~/.cache/claude",
+    "~/.claude",
+    "~/.config/claude",
+    "~/.local/share/claude",
+    "~/.local/state/claude",
+  ]
+end


### PR DESCRIPTION
## Summary

- Add `claude-code-linux` cask — Anthropic's AI coding CLI as a standalone binary
- Livecheck targets **npm registry** instead of GCS `/stable` endpoint for faster version detection
- Closes #308

## Why npm-based livecheck?

The official `homebrew-cask` formula uses GCS `/stable` for livecheck, but this endpoint lags behind actual releases:

| Source | Version (today) |
|--------|-----------------|
| npm registry (`dist-tags.latest`) | **2.1.117** |
| GCS `/stable` | 2.1.104 |
| GCS binary for 2.1.117 | **exists** (HTTP 200, SHA256 verified) |

Anthropic publishes binaries to GCS for every version but doesn't update the `/stable` pointer immediately. Using the npm registry as the livecheck source catches new versions as soon as they're released, while still downloading the native binary from GCS.

## Cask details

- **Source**: standalone Linux x86_64 binary from GCS (~227 MB)
- **No dependencies**: no RPM extraction, no AppImage, no preflight scripts
- **Livecheck**: regex on npm registry JSON (`"latest": "<version>"`)

## Test plan

- [x] SHA256 verified against downloaded binary
- [x] Livecheck regex tested against live npm registry response
- [x] GCS binary URL pattern confirmed working for current version