### PR TITLE
ydotool: drop stale bottle block to republish

### DIFF
--- a/Formula/ydotool.rb
+++ b/Formula/ydotool.rb
@@ -11,10 +11,6 @@ class Ydotool < Formula
     strategy :github_latest
   end
 
-  bottle do
-    sha256 x86_64_linux: "66a00b7830a0c9703c7ae073fa3f45f2f2409a84aeeae463c77262ecd330e7fa"
-  end
-
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "scdoc" => :build


### PR DESCRIPTION
The bottle block at `Formula/ydotool.rb:14-16` references a GitHub release (`ydotool-1.0.4`) that was never actually created, so `brew install` cannot fetch the bottle and has to fall back to source builds.

Removing the orphan block so that labeling this PR `pr-pull` will cause `publish.yml` to build bottles on the CI matrix (x86_64 + arm64) and publish a proper release with SHAs written back into the formula.

Blocks `projectbluefin/common#288` (dxnext), which needs ydotool installable via Homebrew without building from source.

Fixes #301