### PR TITLE
Add Justfile for local CI testing

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,3 @@
+# Run local Homebrew CI tests (syntax, style, and audit checks)
+test:
+    brew test-bot --only-tap-syntax --tap=ublue-os/experimental-tap


### PR DESCRIPTION
This PR adds a Justfile to allow developers to easily replicate the Homebrew CI tests locally using 'just test'. This ensures a consistent testing environment and helps catch systemic failures before pushing.