### PR TITLE
Add Antigravity IDE cask

### DIFF
--- a/Casks/antigravity-ide-linux.rb
+++ b/Casks/antigravity-ide-linux.rb
@@ -1,0 +1,102 @@
+cask "antigravity-ide-linux" do
+  arch arm: "arm", intel: "x64"
+  os linux: "linux"
+
+  version "2.0.1,4861014005645312"
+
+  on_linux do
+    sha256 arm64_linux:  "38e9cc0beb7d7782e0e7b2410e50945d56d66391a79989de391b9ba544a2697e",
+           x86_64_linux: "747163aa3a8afba4b316f97c40b4a75ca4736a59768a416cd1e881e73ec31ef9"
+  end
+
+  url "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/#{version.csv.first}-#{version.csv.second}/linux-#{arch}/Antigravity%20IDE.tar.gz",
+      verified: "edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/"
+  name "Google Antigravity IDE"
+  desc "AI Coding Agent IDE"
+  homepage "https://antigravity.google/"
+
+  livecheck do
+    url "https://antigravity-auto-updater-974169037036.us-central1.run.app/api/update/linux-x64/stable/latest"
+    regex(%r{/stable/([^/]+)/}i)
+    strategy :json do |json, regex|
+      match = json["url"]&.match(regex)
+      next if match.blank?
+
+      match[1]&.tr("-", ",").to_s
+    end
+  end
+
+  binary "#{staged_path}/Antigravity IDE/bin/antigravity-ide", target: "antigravity"
+  binary "#{staged_path}/Antigravity IDE/bin/antigravity-ide", target: "agy"
+  bash_completion "#{staged_path}/Antigravity IDE/resources/completions/bash/antigravity-ide"
+  zsh_completion  "#{staged_path}/Antigravity IDE/resources/completions/zsh/_antigravity-ide"
+  artifact "antigravity.desktop",
+           target: "#{Dir.home}/.local/share/applications/antigravity.desktop"
+  artifact "antigravity-url-handler.desktop",
+           target: "#{Dir.home}/.local/share/applications/antigravity-url-handler.desktop"
+  artifact "antigravity.png",
+           target: "#{Dir.home}/.local/share/icons/hicolor/512x512/apps/antigravity.png"
+
+  preflight do
+    FileUtils.mkdir_p "#{Dir.home}/.local/share/applications"
+    FileUtils.mkdir_p "#{Dir.home}/.local/share/icons/hicolor/512x512/apps"
+
+    # Copy icon from extracted archive
+    icon_path = "Antigravity IDE/resources/app/out/vs/workbench/contrib/antigravityCustomAppIcon"
+    icon_source = "#{staged_path}/#{icon_path}/browser/media/antigravity/antigravity.png"
+    FileUtils.cp icon_source, "#{staged_path}/antigravity.png" if File.exist?(icon_source)
+
+    File.write("#{staged_path}/antigravity.desktop", <<~EOS)
+      [Desktop Entry]
+      Name=Antigravity
+      Comment=AI Coding Agent IDE
+      GenericName=Text Editor
+      Exec="#{HOMEBREW_PREFIX}/bin/antigravity" %F
+      Icon=#{Dir.home}/.local/share/icons/hicolor/512x512/apps/antigravity.png
+      Type=Application
+      StartupNotify=false
+      StartupWMClass=Antigravity
+      Categories=TextEditor;Development;IDE;
+      MimeType=text/plain;inode/directory;application/x-code-workspace;x-scheme-handler/antigravity;
+      Actions=new-empty-window;
+      Keywords=antigravity;code;editor;ai;
+
+      [Desktop Action new-empty-window]
+      Name=New Empty Window
+      Exec="#{HOMEBREW_PREFIX}/bin/antigravity" --new-window %F
+      Icon=#{Dir.home}/.local/share/icons/hicolor/512x512/apps/antigravity.png
+    EOS
+
+    File.write("#{staged_path}/antigravity-url-handler.desktop", <<~EOS)
+      [Desktop Entry]
+      Name=Antigravity - URL Handler
+      Comment=AI Coding Agent IDE
+      GenericName=Text Editor
+      Exec="#{HOMEBREW_PREFIX}/bin/antigravity" --open-url "%U"
+      Icon=#{Dir.home}/.local/share/icons/hicolor/512x512/apps/antigravity.png
+      Type=Application
+      NoDisplay=true
+      Terminal=false
+      StartupNotify=true
+      StartupWMClass=antigravity
+      Categories=Utility;TextEditor;Development;IDE;
+      MimeType=x-scheme-handler/antigravity;
+      Keywords=antigravity;
+    EOS
+
+    # Create a placeholder icon if extraction fails
+    FileUtils.touch "#{staged_path}/antigravity.png" unless File.exist?("#{staged_path}/antigravity.png")
+  end
+
+  zap trash: [
+    "~/.antigravity",
+    "~/.config/Antigravity",
+    "~/.config/antigravity",
+  ]
+
+  caveats <<~EOS
+    If authentication fails or the browser doesn't open Antigravity, try running:
+      xdg-mime default antigravity-url-handler.desktop x-scheme-handler/antigravity
+      update-desktop-database ~/.local/share/applications
+  EOS
+end


### PR DESCRIPTION
Adds antigravity-ide-linux cask for Google Antigravity IDE (v2.0.1).

## Features
- Supports both ARM64 and x86_64 Linux architectures  
- Based on the promoted ublue-os cask pattern for smooth transitions
- Includes shell completions, desktop entries, and icon extraction
- Auto-updates via livecheck to the official updater API

## Testing
- Binary tested and works correctly
- Verified SHA256 checksums for both architectures