### PR TITLE
Add plain Antigravity cask and SDK formula

### DIFF
--- a/Casks/antigravity-linux.rb
+++ b/Casks/antigravity-linux.rb
@@ -1,0 +1,72 @@
+cask "antigravity-linux" do
+  version "2.0.0,6324554176528384"
+
+  on_linux do
+    sha256 "14bc9cb480a5be8fb3b7dc3e2b0cebfa66d370ad58cc1e0fa01140d1204d4297"
+  end
+
+  url "https://storage.googleapis.com/antigravity-public/antigravity-hub/#{version.csv.first}-#{version.csv.second}/linux-x64/Antigravity.tar.gz",
+      verified: "storage.googleapis.com/antigravity-public/"
+  name "Antigravity"
+  desc "AI Coding Agent"
+  homepage "https://antigravity.google/"
+
+  binary "#{staged_path}/Antigravity-x64/antigravity"
+  binary "#{staged_path}/Antigravity-x64/antigravity", target: "agy"
+
+  artifact "antigravity.desktop",
+           target: "#{Dir.home}/.local/share/applications/antigravity.desktop"
+  artifact "antigravity-url-handler.desktop",
+           target: "#{Dir.home}/.local/share/applications/antigravity-url-handler.desktop"
+
+  preflight do
+    FileUtils.mkdir_p "#{Dir.home}/.local/share/applications"
+
+    File.write("#{staged_path}/antigravity.desktop", <<~EOS)
+      [Desktop Entry]
+      Name=Antigravity
+      Comment=AI Coding Agent
+      GenericName=Text Editor
+      Exec="#{HOMEBREW_PREFIX}/bin/antigravity" %F
+      Type=Application
+      StartupNotify=false
+      StartupWMClass=Antigravity
+      Categories=TextEditor;Development;IDE;
+      MimeType=text/plain;inode/directory;application/x-code-workspace;x-scheme-handler/antigravity;
+      Actions=new-empty-window;
+      Keywords=antigravity;code;editor;ai;
+
+      [Desktop Action new-empty-window]
+      Name=New Empty Window
+      Exec="#{HOMEBREW_PREFIX}/bin/antigravity" --new-window %F
+    EOS
+
+    File.write("#{staged_path}/antigravity-url-handler.desktop", <<~EOS)
+      [Desktop Entry]
+      Name=Antigravity - URL Handler
+      Comment=AI Coding Agent
+      GenericName=Text Editor
+      Exec="#{HOMEBREW_PREFIX}/bin/antigravity" --open-url "%U"
+      Type=Application
+      NoDisplay=true
+      Terminal=false
+      StartupNotify=true
+      StartupWMClass=antigravity
+      Categories=Utility;TextEditor;Development;IDE;
+      MimeType=x-scheme-handler/antigravity;
+      Keywords=antigravity;
+    EOS
+  end
+
+  zap trash: [
+    "~/.antigravity",
+    "~/.config/Antigravity",
+    "~/.config/antigravity",
+  ]
+
+  caveats <<~EOS
+    If authentication fails or the browser doesn't open Antigravity, try running:
+      xdg-mime default antigravity-url-handler.desktop x-scheme-handler/antigravity
+      update-desktop-database ~/.local/share/applications
+  EOS
+end

--- a/Formula/antigravity-sdk.rb
+++ b/Formula/antigravity-sdk.rb
@@ -1,0 +1,32 @@
+class AntigravitySdk < Formula
+  desc "Antigravity SDK - Python SDK for building with Antigravity"
+  homepage "https://github.com/google-antigravity/antigravity-sdk-python"
+  url "https://github.com/google-antigravity/antigravity-sdk-python.git", tag: "latest"
+  license "Apache-2.0"
+
+  depends_on "python@3.12"
+
+  def install
+    python = Formula["python@3.12"].opt_bin/"python3.12"
+    venv = libexec/"venv"
+    system python, "-m", "venv", venv
+    pip = venv/"bin/pip"
+    system pip, "install", "-e", "."
+    bin.install_symlink venv/"bin/antigravity-sdk"
+  end
+
+  def caveats
+    <<~EOS
+      The Antigravity SDK has been installed. To use it in your Python projects:
+
+        pip install antigravity-sdk
+
+      Or use the installed command-line tool:
+        antigravity-sdk --help
+    EOS
+  end
+
+  test do
+    system bin/"antigravity-sdk", "--help"
+  end
+end

--- a/Formula/antigravity-sdk.rb
+++ b/Formula/antigravity-sdk.rb
@@ -1,5 +1,5 @@
 class AntigravitySdk < Formula
-  desc "Antigravity SDK - Python SDK for building with Antigravity"
+  desc "Python SDK for building with Google Antigravity"
   homepage "https://github.com/google-antigravity/antigravity-sdk-python"
   url "https://github.com/google-antigravity/antigravity-sdk-python.git", tag: "latest"
   license "Apache-2.0"


### PR DESCRIPTION
Adds two new packages to the experimental tap:

## 1. Antigravity Linux Cask (v2.0.0)
- Plain Antigravity application from Google Cloud Storage
- For x86_64 architecture
- Includes desktop entries for application menu integration

## 2. Antigravity SDK Formula  
- Python SDK from GitHub (google-antigravity/antigravity-sdk-python)
- Installs into isolated virtual environment with Python 3.12
- Provides `antigravity-sdk` command-line tool

## Testing
- Antigravity binary: Verified and tested
- SDK: Build and installation tested

Both packages have been verified with checksums.