### PR TITLE
Add Antigravity IDE cask

### DIFF
--- a/Casks/antigravity-linux.rb
+++ b/Casks/antigravity-linux.rb
@@ -1,4 +1,4 @@
-cask "antigravity-ide-linux" do
+cask "antigravity-linux" do
   arch arm: "arm", intel: "x64"
   os linux: "linux"
 
@@ -27,7 +27,6 @@ cask "antigravity-ide-linux" do
   end
 
   binary "#{staged_path}/Antigravity IDE/bin/antigravity-ide", target: "antigravity"
-  binary "#{staged_path}/Antigravity IDE/bin/antigravity-ide", target: "agy"
   bash_completion "#{staged_path}/Antigravity IDE/resources/completions/bash/antigravity-ide"
   zsh_completion  "#{staged_path}/Antigravity IDE/resources/completions/zsh/_antigravity-ide"
   artifact "antigravity.desktop",


### PR DESCRIPTION
## Summary
- Add antigravity-linux cask for IDE v2.0.1 with multi-arch support (arm, x64)
- Downloads from edgedl.me.gvt1.com with desktop integration
- Installs desktop entry files and shell completions
- agy alias removed per requirements

## Test plan
- [ ] `brew install --cask ublue-os/experimental-tap/antigravity-linux`
- [ ] `antigravity` command launches IDE
- [ ] Desktop entry appears in application menu
- [ ] Uninstall cleans up config directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)