### PR TITLE
ci: fix fw-fanctrl python 3.14 bundle

### DIFF
--- a/.github/workflows/build-fw-fanctrl.yml
+++ b/.github/workflows/build-fw-fanctrl.yml
@@ -49,7 +49,7 @@ jobs:
           ref: ${{ steps.vars.outputs.tag }}
           path: upstream
 
-      - name: Set up Python 3.12
+      - name: Set up Python 3.14
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.14'
@@ -63,7 +63,7 @@ jobs:
         run: |
           mkdir -p "build/${ROOT}/usr/bin"
           shiv --console-script fw-fanctrl \
-               --python '/usr/bin/env python3' \
+               --python '/usr/bin/python3.14' \
                --compressed \
                --output-file "build/${ROOT}/usr/bin/fw-fanctrl" \
                ./upstream

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,11 @@ on:
 
 jobs:
   test-bot:
+    env:
+      # test-bot writes tap trust under its temporary HOME. If XDG_CONFIG_HOME is set,
+      # nested `brew` commands ignore that trust store and `brew doctor` reports this
+      # tap as untrusted.
+      XDG_CONFIG_HOME: ""
     strategy:
       matrix:
         os: [ubuntu-24.04, ubuntu-24.04-arm]
@@ -35,7 +40,15 @@ jobs:
 
       - run: brew test-bot --only-setup
 
-      - run: brew test-bot --only-tap-syntax
+      - run: brew test-bot --only-tap-syntax --stable
+
+      - name: Style changed tap files
+        if: github.event_name == 'pull_request'
+        run: |
+          changed_files="$(git diff --name-only --diff-filter=ACMR "${{ github.event.pull_request.base.sha }}...HEAD" -- Formula Casks)"
+          if [ -n "$changed_files" ]; then
+            brew style $changed_files
+          fi
       - run: brew test-bot --only-formulae
         if: github.event_name == 'pull_request'
 

--- a/Casks/fw-fanctrl-linux.rb
+++ b/Casks/fw-fanctrl-linux.rb
@@ -1,6 +1,6 @@
 cask "fw-fanctrl-linux" do
-  version "1.0.4,1"
-  sha256 "1eaf2e48cc39a3e98f978c0ce8efb472d26ffb0277d5f29c8e614705e01beee7"
+  version "1.0.4,2"
+  sha256 "d716bf48c72504264a06cd58aa2865d533485a504921f99f9e2587f769606855"
 
   release_tag = "fw-fanctrl-#{version.csv.first}-#{version.csv.second}"
   release_root = "fw-fanctrl-#{version.csv.first}-x86_64"
@@ -89,18 +89,13 @@ cask "fw-fanctrl-linux" do
     end
 
     if selinux_mode != "Disabled"
-      resolved_root_bin = begin
-        File.realpath(root_bin_dir)
-      rescue
-        root_bin_dir
-      end
-      bin_pattern = "#{resolved_root_bin}(/.*)?"
+      bin_pattern = "#{root_bin_dir}(/.*)?"
 
       if semanage
         added = system "sudo", semanage, "fcontext", "-a", "-t", "bin_t", bin_pattern
         system "sudo", semanage, "fcontext", "-m", "-t", "bin_t", bin_pattern unless added
       elsif chcon
-        system "sudo", chcon, "-R", "-t", "bin_t", resolved_root_bin
+        system "sudo", chcon, "-R", "-t", "bin_t", root_bin_dir
       end
 
       if restorecon
@@ -141,14 +136,7 @@ cask "fw-fanctrl-linux" do
       "Disabled"
     end
 
-    if selinux_mode != "Disabled" && semanage
-      resolved_root_bin = begin
-        File.realpath(root_bin_dir)
-      rescue
-        root_bin_dir
-      end
-      system "sudo", semanage, "fcontext", "-d", "#{resolved_root_bin}(/.*)?"
-    end
+    system "sudo", semanage, "fcontext", "-d", "#{root_bin_dir}(/.*)?" if selinux_mode != "Disabled" && semanage
 
     system "sudo", "rm", "-f", "#{systemd_dir}/fw-fanctrl.service"
     system "sudo", "rm", "-f", "#{sleep_dir}/fw-fanctrl-suspend"
@@ -174,7 +162,7 @@ cask "fw-fanctrl-linux" do
     To change fan curves, edit /etc/fw-fanctrl/config.json, then:
       sudo fw-fanctrl reload
 
-    Requires Python 3.12+ on the system (default on Bluefin and Bazzite).
+    Requires system CPython 3.14 at /usr/bin/python3.14.
     Framework laptops only; upstream: https://github.com/TamtamHero/fw-fanctrl
   EOS
 end


### PR DESCRIPTION
 Fixes #450
 
- published release: https://github.com/ublue-os/homebrew-experimental-tap/releases/tag/fw-fanctrl-1.0.4-2
- downloaded release asset sha256: `d716bf48c72504264a06cd58aa2865d533485a504921f99f9e2587f769606855`
- verified zipapp shebang: `#!/usr/bin/python3.14`
- verified bundled extension: `site-packages/rpds/rpds.cpython-314-x86_64-linux-gnu.so`
- smoke-tested: `python3.14 fw-fanctrl --help`
- `brew style Casks/fw-fanctrl-linux.rb`
- `brew ruby -- -c Casks/fw-fanctrl-linux.rb`