### PR TITLE
I moved the on_arch_conditional calls up to the top level of the cask DSL

### DIFF
--- a/Casks/emacs-app-linux.rb
+++ b/Casks/emacs-app-linux.rb
@@ -5,6 +5,9 @@ cask "emacs-app-linux" do
   sha256 on_arch_conditional intel: "2d3d1c145fe8f0edf51f1275c5109eee116f98e2899498ca710ab96858fa0a70",
                              arm:   "d2471179e3a7691148a585c04c573a9dc95ee26b448624f4a8131d73c2234698"
 
+  arch_str = on_arch_conditional arm: "arm64", intel: "amd64"
+  target_triplet = on_arch_conditional arm: "aarch64-unknown-linux-gnu", intel: "x86_64-pc-linux-gnu"
+
   url "https://github.com/daegalus/linux-app-builds/releases/download/emacs-pgtk-#{version}/emacs-pgtk-#{version.split("-").first}-fedora-latest-#{arch}.tar.gz",
       verified: "github.com/daegalus/linux-app-builds/"
   name "Emacs PGTK"
@@ -43,8 +46,6 @@ cask "emacs-app-linux" do
            target: "#{HOMEBREW_PREFIX}/opt/emacs-app-linux/libexec"
 
   preflight do
-    arch_str = on_arch_conditional arm: "arm64", intel: "amd64"
-
     emacs_version = version.split("-").first
     staged_prefix = "#{staged_path}/emacs-pgtk-#{emacs_version}-fedora-latest-#{arch_str}"
 
@@ -54,7 +55,6 @@ cask "emacs-app-linux" do
     # Create symlink to pdmp file in bin directory - Emacs automatically finds it there
     # Emacs looks for {binary-name}.pdmp next to the binary (e.g., emacs-30.2.pdmp)
     # Using a relative symlink saves ~12MB compared to copying
-    target_triplet = on_arch_conditional arm: "aarch64-unknown-linux-gnu", intel: "x86_64-pc-linux-gnu"
     pdmp_source = Dir.glob("#{staged_prefix}/libexec/emacs/#{emacs_version}/#{target_triplet}/*.pdmp").first
     if pdmp_source
       relative_path = "../libexec/emacs/#{emacs_version}/#{target_triplet}/#{File.basename(pdmp_source)}"


### PR DESCRIPTION
When installing the Emacs cask you get 

==> Purging files for version 30.2-18 of Cask emacs-app-linux
Error: undefined method 'on_arch_conditional' for Cask 'emacs-app-linux'

This PR fixes it