### PR TITLE
feat: add claude-desktop-linux (1.24012.9)

### DIFF
--- a/Casks/claude-desktop-linux.rb
+++ b/Casks/claude-desktop-linux.rb
@@ -1,0 +1,46 @@
+cask "claude-desktop-linux" do
+  version "1.22209.3"
+  sha256 "d427f46ac9233dbc4d8a441a602f09f750b8a5f05d1fc7a00285d7a6ce07655c"
+
+  url "https://downloads.claude.ai/claude-desktop/apt/stable/pool/main/c/claude-desktop/claude-desktop_#{version}_amd64.deb"
+  name "Claude"
+  desc "Anthropic's official Claude AI desktop app"
+  homepage "https://claude.com/download"
+
+  livecheck do
+    url "https://downloads.claude.ai/claude-desktop/apt/stable/dists/stable/main/binary-amd64/Packages"
+    regex(/^Version: (\d+\.\d+\.\d+)$/m)
+  end
+
+  depends_on formula: "dpkg"
+
+  binary "usr/bin/claude-desktop", target: "claude-desktop"
+  artifact "usr/share/icons/hicolor/16x16/apps/claude-desktop.png",
+           target: "#{Dir.home}/.local/share/icons/hicolor/16x16/apps/claude-desktop.png"
+  artifact "usr/share/icons/hicolor/32x32/apps/claude-desktop.png",
+           target: "#{Dir.home}/.local/share/icons/hicolor/32x32/apps/claude-desktop.png"
+  artifact "usr/share/icons/hicolor/48x48/apps/claude-desktop.png",
+           target: "#{Dir.home}/.local/share/icons/hicolor/48x48/apps/claude-desktop.png"
+  artifact "usr/share/icons/hicolor/128x128/apps/claude-desktop.png",
+           target: "#{Dir.home}/.local/share/icons/hicolor/128x128/apps/claude-desktop.png"
+  artifact "usr/share/icons/hicolor/256x256/apps/claude-desktop.png",
+           target: "#{Dir.home}/.local/share/icons/hicolor/256x256/apps/claude-desktop.png"
+  artifact "usr/share/applications/com.anthropic.Claude.desktop",
+           target: "#{Dir.home}/.local/share/applications/com.anthropic.Claude.desktop"
+
+  preflight do
+    system "#{formula_opt_bin("dpkg")}/dpkg-deb", "-x",
+           "#{staged_path}/claude-desktop_#{version}_amd64.deb", staged_path
+
+    desktop_file = "#{staged_path}/usr/share/applications/com.anthropic.Claude.desktop"
+    content = File.read(desktop_file)
+    content.gsub!(/^Exec=.*/, "Exec=#{HOMEBREW_PREFIX}/bin/claude-desktop %U")
+    File.write(desktop_file, content)
+  end
+
+  zap trash: [
+    "~/.cache/Claude",
+    "~/.config/Claude",
+    "~/.local/share/Claude",
+  ]
+end

--- a/Casks/claude-desktop-linux.rb
+++ b/Casks/claude-desktop-linux.rb
@@ -35,6 +35,7 @@ cask "claude-desktop-linux" do
     desktop_file = "#{staged_path}/usr/share/applications/com.anthropic.Claude.desktop"
     content = File.read(desktop_file)
     content.gsub!(/^Exec=.*/, "Exec=#{HOMEBREW_PREFIX}/bin/claude-desktop %U")
+    content.gsub!(/^Icon=.*/, "Icon=#{Dir.home}/.local/share/icons/hicolor/256x256/apps/claude-desktop.png")
     File.write(desktop_file, content)
   end
 

--- a/Casks/claude-desktop-linux.rb
+++ b/Casks/claude-desktop-linux.rb
@@ -1,6 +1,6 @@
 cask "claude-desktop-linux" do
-  version "1.22209.3"
-  sha256 "d427f46ac9233dbc4d8a441a602f09f750b8a5f05d1fc7a00285d7a6ce07655c"
+  version "1.24012.9"
+  sha256 "302e6d208dd8c8e9e52067daa28ef3b1171a1613586fd0e10bedc642225b6ee1"
 
   url "https://downloads.claude.ai/claude-desktop/apt/stable/pool/main/c/claude-desktop/claude-desktop_#{version}_amd64.deb"
   name "Claude"


### PR DESCRIPTION
Based on beta .deb file from Anthropic APT repo. Already passed `brew style` locally.
Docs on Claude Desktop for Linux: https://code.claude.com/docs/en/desktop-linux

<img width="828" height="381" alt="image" src="https://github.com/user-attachments/assets/e4f97f86-5d36-4544-8b11-92bd555ba8a8" />

<img width="472" height="263" alt="Screenshot From 2026-07-20 16-55-13" src="https://github.com/user-attachments/assets/6af96468-1808-40d7-a1d0-3cb6990b9cee" />

<img width="1366" height="768" alt="Screenshot From 2026-07-20 10-31-09" src="https://github.com/user-attachments/assets/131c8d7c-28bd-4c5f-9e71-a9c706645188" />

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/2742cc70-1006-4a17-9ce5-82c82d4f792a" />

Assisted-by: Kimi K2.7 Code, GLM 5.2 in OpenCode
https://opncd.ai/share/etG3pA8z