### PR TITLE
Add gitkraken-linux cask

### DIFF
--- a/Casks/gitkraken-linux.rb
+++ b/Casks/gitkraken-linux.rb
@@ -1,0 +1,46 @@
+cask "gitkraken-linux" do
+  version "12.3.1"
+  sha256 "377f3b94ff1df9225906bc8134d505b14c1e6be82dea07463e14a62439b3319d"
+
+  url "https://api.gitkraken.dev/releases/production/linux/x64/#{version}/gitkraken-amd64.tar.gz",
+      verified: "api.gitkraken.dev/releases/production/"
+  name "GitKraken"
+  desc "Git client focusing on productivity"
+  homepage "https://www.gitkraken.com/"
+
+  livecheck do
+    url "https://release.gitkraken.com/linux/RELEASES?v=0.0.0&linux=999"
+    strategy :json do |json|
+      json["name"]
+    end
+  end
+
+  auto_updates true
+
+  binary "gitkraken/gitkraken"
+  artifact "gitkraken.desktop",
+           target: "#{Dir.home}/.local/share/applications/gitkraken.desktop"
+
+  preflight do
+    FileUtils.mkdir_p "#{Dir.home}/.local/share/applications"
+
+    File.write "#{staged_path}/gitkraken.desktop", <<~EOS
+      [Desktop Entry]
+      Name=GitKraken
+      Comment=Git client focusing on productivity
+      Exec=#{HOMEBREW_PREFIX}/bin/gitkraken %U
+      Icon=#{staged_path}/gitkraken/gitkraken.png
+      Terminal=false
+      Type=Application
+      Categories=Development;RevisionControl;
+      StartupWMClass=GitKraken
+    EOS
+  end
+
+  zap trash: [
+    "~/.cache/GitKraken",
+    "~/.config/GitKraken",
+    "~/.gitkraken",
+    "~/.local/share/applications/gitkraken.desktop",
+  ]
+end


### PR DESCRIPTION
The GitKraken experience as a Linux cask is better than the unofficial Flatpak because it provides simpler integration with editors, IDEs, and terminals. I see it as a similar situation to using the VS Code cask instead of the Flatpak.

This is my first cask, I used the macOS cask as its basis: https://github.com/Homebrew/homebrew-cask/blob/main/Casks/g/gitkraken.rb