### PR TITLE
feat(cask): add ChatGPT for Linux

### DIFF
--- a/Casks/chatgpt-linux.rb
+++ b/Casks/chatgpt-linux.rb
@@ -1,0 +1,55 @@
+cask "chatgpt-linux" do
+  arch arm: "aarch64", intel: "x86_64"
+  deb_arch = on_arch_conditional arm: "arm64", intel: "amd64"
+  os linux: "linux"
+
+  version "26.803.81509"
+  sha256 arm:          "290b1f2d0f57a508df23e308a6d0d643063767b684906dfb916ce4b01ecfdac9",
+         intel:        "4d34fd4bb1122b7f2445f6a1bbc7c869cd3724c9f71aee3802795272c0b10702",
+         arm64_linux:  "290b1f2d0f57a508df23e308a6d0d643063767b684906dfb916ce4b01ecfdac9",
+         x86_64_linux: "4d34fd4bb1122b7f2445f6a1bbc7c869cd3724c9f71aee3802795272c0b10702"
+
+  url "https://persistent.oaistatic.com/codex-app-prod/linux/rpm/#{arch}/chatgpt-#{version}-1.#{arch}.rpm"
+  name "ChatGPT"
+  desc "OpenAI's official ChatGPT desktop app"
+  homepage "https://chatgpt.com/"
+
+  livecheck do
+    url "https://persistent.oaistatic.com/codex-app-prod/linux/deb/dists/stable/main/binary-#{deb_arch}/Packages"
+    regex(/^Version:\s*(\d+(?:\.\d+)+)$/i)
+  end
+
+  auto_updates true
+  depends_on formula: "cpio"
+  depends_on formula: "rpm2cpio"
+
+  binary "usr/lib/chatgpt/codex-launcher", target: "chatgpt"
+  artifact "usr/share/applications/chatgpt.desktop",
+           target: "#{Dir.home}/.local/share/applications/chatgpt.desktop"
+  artifact "usr/share/pixmaps/chatgpt.png",
+           target: "#{Dir.home}/.local/share/pixmaps/chatgpt.png"
+
+  preflight do
+    rpm2cpio = Formula["rpm2cpio"].bin/"rpm2cpio"
+    cpio = Formula["cpio"].bin/"cpio"
+    rpm_path = staged_path/"chatgpt-#{version}-1.#{arch}.rpm"
+    system "sh", "-c", "'#{rpm2cpio}' '#{rpm_path}' | '#{cpio}' -idm --quiet", chdir: staged_path
+    FileUtils.rm rpm_path
+
+    desktop_file = staged_path/"usr/share/applications/chatgpt.desktop"
+    content = File.read(desktop_file)
+    content.gsub!(/^Exec=.*/, "Exec=#{HOMEBREW_PREFIX}/bin/chatgpt %U")
+    content.gsub!(/^Icon=.*/, "Icon=#{Dir.home}/.local/share/pixmaps/chatgpt.png")
+    File.write(desktop_file, content)
+  end
+
+  zap trash: [
+        "~/.cache/ChatGPT",
+        "~/.cache/Codex",
+        "~/.config/ChatGPT",
+        "~/.config/Codex",
+        "~/.local/share/ChatGPT",
+        "~/.local/share/Codex",
+      ],
+      rmdir: "~/.codex"
+end


### PR DESCRIPTION
## Summary

This adds OpenAI's official ChatGPT desktop app for Linux, with support for both x86_64 and ARM64 systems.

1. **Adds architecture-specific RPM packages.** The cask uses versioned RPM URLs and checksums from OpenAI's Linux repositories for reproducible installs.

2. **Uses Linux release metadata for livecheck.** Version updates are detected from OpenAI's stable Linux package index rather than relying on the macOS appcast.

3. **Integrates with the Linux desktop.** The RPM is extracted with `rpm2cpio` and `cpio`, then the ChatGPT launcher, desktop entry, and icon are installed with Homebrew-compatible paths.

Verified: `brew style`, Ruby syntax, cask audit, and livecheck pass. Both RPM architectures were extracted successfully, runtime verification on Linux is still needed.
