### PR TITLE
fix: repair the bump auto-promotion pipeline

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -7,41 +7,60 @@ on:
       - completed
   workflow_dispatch:
 
+concurrency:
+  group: automerge
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
-  dispatch-tests:
+  discover:
     runs-on: ubuntu-24.04
-    if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
+    # `brew bump` routinely fails on one package while opening perfectly good PRs
+    # for others, so a failed Homebrew Bump must not stop the good PRs from being
+    # promoted. Only a cancelled run is skipped.
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion != 'cancelled'
+    outputs:
+      prs: ${{ steps.find.outputs.prs }}
     steps:
-      - name: Dispatch CI for Bump PRs
+      - name: Find open bump PRs
+        id: find
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const { owner, repo } = context.repo;
 
-            // Find open PRs by bump users
-            // You can adjust the query as per your needs, e.g., filter by labels if added
-            const { data: pulls } = await github.rest.pulls.list({
+            const pulls = await github.paginate(github.rest.pulls.list, {
               owner,
               repo,
               state: 'open',
-              per_page: 50
+              per_page: 100,
             });
 
-            for (const pr of pulls) {
-              const isBumpBot = ['lambdaclan', 'app/github-actions'].includes(pr.user.login);
-              const isBumpBranch = pr.head.ref.startsWith('bump-');
+            const bumpUsers = ['lambdaclan', 'app/github-actions'];
+            const prs = pulls
+              .filter((pr) => !pr.draft)
+              .filter((pr) => bumpUsers.includes(pr.user.login) || pr.head.ref.startsWith('bump-'))
+              .map((pr) => pr.number.toString());
 
-              if ((isBumpBot || isBumpBranch) && !pr.draft) {
-                console.log(`Dispatching Bump CI for PR #${pr.number}`);
+            core.info(`Bump PRs to test: ${prs.length ? prs.join(', ') : '(none)'}`);
+            core.setOutput('prs', JSON.stringify(prs));
 
-                await github.rest.actions.createWorkflowDispatch({
-                  owner,
-                  repo,
-                  workflow_id: 'bump-ci.yml',
-                  ref: 'main',
-                  inputs: {
-                    pr_number: pr.number.toString()
-                  }
-                });
-              }
-            }
+  bump-ci:
+    needs: discover
+    # An empty matrix vector is a hard error, so skip the job when nothing is open.
+    if: needs.discover.outputs.prs != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        pr: ${{ fromJson(needs.discover.outputs.prs) }}
+    uses: ./.github/workflows/bump-ci.yml
+    with:
+      pr_number: ${{ matrix.pr }}
+    permissions:
+      contents: read
+      actions: read
+      checks: read
+      pull-requests: write

--- a/.github/workflows/bump-ci.yml
+++ b/.github/workflows/bump-ci.yml
@@ -10,6 +10,10 @@ on:
 jobs:
   test-and-label:
     env:
+      # test-bot writes tap trust under its temporary HOME. If XDG_CONFIG_HOME is set,
+      # nested `brew` commands ignore that trust store and `brew doctor` reports this
+      # tap as untrusted.
+      XDG_CONFIG_HOME: ""
       HOMEBREW_NO_REQUIRE_TAP_TRUST: "1"
     strategy:
       matrix:
@@ -43,7 +47,26 @@ jobs:
 
       - run: brew test-bot --only-cleanup-before
       - run: brew test-bot --only-setup
-      - run: brew test-bot --only-tap-syntax
+
+      # `--stable` restricts TapSyntax to `brew readall`. Without it, test-bot also
+      # runs `brew style` and `brew audit` across the entire tap, so any pre-existing
+      # offence in an unrelated cask fails every bump and severs promotion. Style is
+      # scoped to the files this PR actually touches instead, matching tests.yml.
+      - run: brew test-bot --only-tap-syntax --stable
+
+      - name: Style changed tap files
+        run: |
+          git fetch --quiet origin main
+          base="$(git merge-base origin/main HEAD)"
+          changed_files="$(git diff --name-only --diff-filter=ACMR "$base...HEAD" -- Formula Casks)"
+          if [ -n "$changed_files" ]; then
+            echo "Styling: $changed_files"
+            # shellcheck disable=SC2086
+            brew style $changed_files
+          else
+            echo "No Formula or Casks changes to style."
+          fi
+
       - run: brew test-bot --only-formulae
 
       - name: Label PR on Success

--- a/.github/workflows/bump-ci.yml
+++ b/.github/workflows/bump-ci.yml
@@ -6,6 +6,18 @@ on:
       pr_number:
         description: "Pull Request Number"
         required: true
+  # Called by automerge.yml so Bump CI's result is a real job result rather than a
+  # fire-and-forget dispatch whose failure nothing observes.
+  workflow_call:
+    inputs:
+      pr_number:
+        description: "Pull Request Number"
+        required: true
+        type: string
+
+concurrency:
+  group: bump-ci-${{ inputs.pr_number }}
+  cancel-in-progress: true
 
 jobs:
   test-and-label:

--- a/.github/workflows/bump-ci.yml
+++ b/.github/workflows/bump-ci.yml
@@ -43,12 +43,19 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Store PR Ref
+      # Pin the SHA up front and test exactly that commit. Previously this stored
+      # PR_REF (with literal quotes baked into the value) and never read it back,
+      # so a push landing mid-run was tested at one SHA and promoted at another.
+      - name: Check out the PR head SHA
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          head_sha="$(gh pr view "${{ inputs.pr_number }}" \
+            --repo "${{ github.repository }}" --json headRefOid --jq .headRefOid)"
+          echo "Testing PR #${{ inputs.pr_number }} at $head_sha"
           gh pr checkout "${{ inputs.pr_number }}"
-          echo "PR_REF=\"$(git rev-parse HEAD)\"" >> "$GITHUB_ENV"
+          git checkout --quiet --detach "$head_sha"
+          echo "PR_HEAD_SHA=$head_sha" >> "$GITHUB_ENV"
 
       - name: Cache Homebrew Bundler RubyGems
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
@@ -81,9 +88,20 @@ jobs:
 
       - run: brew test-bot --only-formulae
 
+      # Applying `pr-pull` triggers publish.yml, which pushes to main. Only do that
+      # if the head is still the commit that was just tested.
       - name: Label PR on Success
         if: success()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          current_sha="$(gh pr view "${{ inputs.pr_number }}" \
+            --repo "${{ github.repository }}" --json headRefOid --jq .headRefOid)"
+
+          if [ "$current_sha" != "$PR_HEAD_SHA" ]; then
+            echo "::error::PR #${{ inputs.pr_number }} head moved from $PR_HEAD_SHA to $current_sha during testing; refusing to label."
+            exit 1
+          fi
+
           gh pr edit "${{ inputs.pr_number }}" --add-label "pr-pull"
+          echo "Labelled PR #${{ inputs.pr_number }} pr-pull at $PR_HEAD_SHA"

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -48,10 +48,15 @@ jobs:
             echo "INFOPATH=$INFOPATH"
           } >> "$GITHUB_ENV"
 
+      # Attribute bump commits to the bot that actually opens the PR. This was
+      # hardcoded to `lambdaclan`, a real GitHub user who is not a collaborator on
+      # this repo, so every automated commit was authored under their identity while
+      # the PR itself came from github-actions[bot]. That mismatch is also why the
+      # test-bot run on each bump PR sat pending until a maintainer approved it.
       - name: Configure git
         uses: Homebrew/actions/git-user-config@13f73d7cbd2f8f180d85d8f7201698cf110bf84c # main
         with:
-          username: lambdaclan
+          username: github-actions[bot]
 
       # `brew bump` exits non-zero if any single package fails while still opening
       # PRs for the rest, so failure is tolerated here to let the reporting steps

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -33,6 +33,12 @@ jobs:
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           brew tap --force "${{ github.repository }}"
 
+          # `brew audit` resolves build dependencies against the core tap. Without it
+          # bluefin-cli fails every run with "Can't find dependency 'go'", because
+          # this job hand-rolls the Homebrew install rather than using
+          # Homebrew/actions/setup-homebrew (which taps core for the other workflows).
+          brew tap --force homebrew/core
+
           {
             echo "HOMEBREW_PREFIX=$HOMEBREW_PREFIX"
             echo "HOMEBREW_CELLAR=$HOMEBREW_CELLAR"

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: "0 3 * * *" # daily at 03:00 UTC
 
+concurrency:
+  group: homebrew-bump
+  cancel-in-progress: false
+
 jobs:
   bump:
     runs-on: ubuntu-24.04
@@ -43,6 +47,9 @@ jobs:
         with:
           username: lambdaclan
 
+      # `brew bump` exits non-zero if any single package fails while still opening
+      # PRs for the rest, so failure is tolerated here to let the reporting steps
+      # below run. The final step re-raises it so the run is not silently green.
       - name: Bump packages
         id: bump
         continue-on-error: true
@@ -95,3 +102,29 @@ jobs:
                             fi
                           done
                         fi
+
+      # Without this the job is green on every run, because `continue-on-error`
+      # above swallows the failure. That masked 13 packages failing to bump nightly
+      # and made the pipeline look healthy while promotion was dead.
+      - name: Report bump result
+        if: always()
+        run: |
+          {
+            echo "### Homebrew Bump"
+            echo
+            if [ "${{ steps.bump.outcome }}" = "failure" ]; then
+              echo ":x: \`brew bump\` reported errors. Packages that could not be bumped:"
+              echo
+              echo '```'
+              grep -E "^.*##\[error\]|Could not find 'sha256' stanza|brew audit.*failed" bump_output.log \
+                | sed 's/##\[error\]//' | sort -u || echo "(see full log)"
+              echo '```'
+            else
+              echo ":white_check_mark: \`brew bump\` completed with no errors."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "${{ steps.bump.outcome }}" = "failure" ]; then
+            echo "::error::brew bump reported errors; see the job summary."
+            exit 1
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,11 +26,14 @@ jobs:
       - name: Set up git
         uses: Homebrew/actions/git-user-config@13f73d7cbd2f8f180d85d8f7201698cf110bf84c # main
 
+      # --head-sha makes pr-pull refuse to promote anything other than the commit
+      # that carried the label, closing the window between labelling and pulling.
       - name: Pull bottles
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PULL_REQUEST: ${{ github.event.pull_request.number }}
-        run: brew pr-pull --debug --tap="$GITHUB_REPOSITORY" "$PULL_REQUEST"
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: brew pr-pull --debug --tap="$GITHUB_REPOSITORY" --head-sha="$HEAD_SHA" "$PULL_REQUEST"
 
       - name: Push commits
         uses: Homebrew/actions/git-try-push@13f73d7cbd2f8f180d85d8f7201698cf110bf84c # main

--- a/Casks/clion-linux.rb
+++ b/Casks/clion-linux.rb
@@ -3,8 +3,8 @@ cask "clion-linux" do
   os linux: "linux"
 
   version "2026.1.2,261.24374.148"
-  sha256 on_arch_conditional intel: "4372ce869c2953abeb3d613303eb366676d1c68f847a8741507518b375e292bb",
-                             arm:   "60cd74e68ccfefca0b0e6c0a2f4b78678c068c20e1eb1be17ff0b5a020fa422f"
+  sha256 arm64_linux:  "60cd74e68ccfefca0b0e6c0a2f4b78678c068c20e1eb1be17ff0b5a020fa422f",
+         x86_64_linux: "4372ce869c2953abeb3d613303eb366676d1c68f847a8741507518b375e292bb"
 
   url "https://download.jetbrains.com/cpp/CLion-#{version.csv.first}#{arch}.tar.gz"
   name "CLion"

--- a/Casks/clion-linux.rb
+++ b/Casks/clion-linux.rb
@@ -1,6 +1,5 @@
 cask "clion-linux" do
-  arch intel: "",
-       arm:   "-aarch64"
+  arch arm: "-aarch64"
   os linux: "linux"
 
   version "2026.1.2,261.24374.148"

--- a/Casks/cursor-linux.rb
+++ b/Casks/cursor-linux.rb
@@ -3,8 +3,8 @@ cask "cursor-linux" do
   file_arch = on_arch_conditional arm: "aarch64", intel: "x86_64"
 
   version "3.5.38,009bb5a3600dd98fe1c1f25798f767f686e14759"
-  sha256 on_arch_conditional intel: "c6d3349b528995dd517ccc5b3311b819a74e0cd876533c30d7573e01a4226dcf",
-                             arm:   "5385c3929af73f3185df24976587054cf137e4384621e58129752f8ae90f8d50"
+  sha256 arm64_linux:  "5385c3929af73f3185df24976587054cf137e4384621e58129752f8ae90f8d50",
+         x86_64_linux: "c6d3349b528995dd517ccc5b3311b819a74e0cd876533c30d7573e01a4226dcf"
 
   url "https://downloads.cursor.com/production/#{version.csv.second}/linux/#{arch}/Cursor-#{version.csv.first}-#{file_arch}.AppImage",
       verified: "downloads.cursor.com/"

--- a/Casks/datagrip-linux.rb
+++ b/Casks/datagrip-linux.rb
@@ -1,6 +1,5 @@
 cask "datagrip-linux" do
-  arch intel: "",
-       arm:   "-aarch64"
+  arch arm: "-aarch64"
   os linux: "linux"
 
   version "2026.1.3,261.24374.56"

--- a/Casks/datagrip-linux.rb
+++ b/Casks/datagrip-linux.rb
@@ -3,8 +3,8 @@ cask "datagrip-linux" do
   os linux: "linux"
 
   version "2026.1.3,261.24374.56"
-  sha256 on_arch_conditional intel: "5f1c2f5e269601f2b7d7c0636f328f2d50de30194eaf9045b83d9ba94f3ed76a",
-                             arm:   "1beb629c3ffea8ce47551e2ed84d1c357b5d56c6f080af3f3dd67789cea17f83"
+  sha256 arm64_linux:  "1beb629c3ffea8ce47551e2ed84d1c357b5d56c6f080af3f3dd67789cea17f83",
+         x86_64_linux: "5f1c2f5e269601f2b7d7c0636f328f2d50de30194eaf9045b83d9ba94f3ed76a"
 
   url "https://download.jetbrains.com/datagrip/datagrip-#{version.csv.first}#{arch}.tar.gz"
   name "DataGrip"

--- a/Casks/dataspell-linux.rb
+++ b/Casks/dataspell-linux.rb
@@ -3,8 +3,8 @@ cask "dataspell-linux" do
   os linux: "linux"
 
   version "2026.1.2,261.25134.18"
-  sha256 on_arch_conditional intel: "0f978e36b3bee442f572eb24514e1c4582e071b1bb442be5b9c9e6c3db7608e3",
-                             arm:   "4929883c5d290cca25c5e5cbdb551a1cc6d976d61b0a1595c532993ac3e11fe2"
+  sha256 arm64_linux:  "4929883c5d290cca25c5e5cbdb551a1cc6d976d61b0a1595c532993ac3e11fe2",
+         x86_64_linux: "0f978e36b3bee442f572eb24514e1c4582e071b1bb442be5b9c9e6c3db7608e3"
 
   url "https://download.jetbrains.com/python/dataspell-#{version.csv.first}#{arch}.tar.gz"
   name "DataSpell"

--- a/Casks/dataspell-linux.rb
+++ b/Casks/dataspell-linux.rb
@@ -1,6 +1,5 @@
 cask "dataspell-linux" do
-  arch intel: "",
-       arm:   "-aarch64"
+  arch arm: "-aarch64"
   os linux: "linux"
 
   version "2026.1.2,261.25134.18"

--- a/Casks/devpod-linux.rb
+++ b/Casks/devpod-linux.rb
@@ -50,12 +50,12 @@ cask "devpod-linux" do
 
   uninstall_postflight do
     xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
-    FileUtils.rm_f "#{xdg_data}/applications/devpod.desktop"
-    FileUtils.rm_f "#{xdg_data}/icons/hicolor/512x512/apps/devpod.png"
+    FileUtils.rm("#{xdg_data}/applications/devpod.desktop", force: true)
+    FileUtils.rm("#{xdg_data}/icons/hicolor/512x512/apps/devpod.png", force: true)
   end
 
   zap trash: [
-    "~/.devpod",
     "~/.config/devpod",
+    "~/.devpod",
   ]
 end

--- a/Casks/emacs-app-linux.rb
+++ b/Casks/emacs-app-linux.rb
@@ -1,5 +1,10 @@
 cask "emacs-app-linux" do
   arch arm: "arm64", intel: "amd64"
+  # Computed at cask-body scope: `on_arch_conditional` lives on Cask::DSL, not on
+  # the Cask::DSL::Base subclass the flight blocks below are instance_eval'd
+  # against, so calling it inside one would raise NoMethodError at install time.
+  # The blocks close over this local, which instance_eval does not disturb.
+  target_triplet = on_arch_conditional arm: "aarch64-unknown-linux-gnu", intel: "x86_64-pc-linux-gnu"
 
   version "30.2-18"
   sha256 arm64_linux:  "d2471179e3a7691148a585c04c573a9dc95ee26b448624f4a8131d73c2234698",
@@ -43,10 +48,8 @@ cask "emacs-app-linux" do
            target: "#{HOMEBREW_PREFIX}/opt/emacs-app-linux/libexec"
 
   preflight do
-    arch_str = Hardware::CPU.arm? ? "arm64" : "amd64"
-
     emacs_version = version.split("-").first
-    staged_prefix = "#{staged_path}/emacs-pgtk-#{emacs_version}-fedora-latest-#{arch_str}"
+    staged_prefix = "#{staged_path}/emacs-pgtk-#{emacs_version}-fedora-latest-#{arch}"
 
     # Make run-emacs.sh executable
     FileUtils.chmod "+x", "#{staged_prefix}/run-emacs.sh"
@@ -54,7 +57,6 @@ cask "emacs-app-linux" do
     # Create symlink to pdmp file in bin directory - Emacs automatically finds it there
     # Emacs looks for {binary-name}.pdmp next to the binary (e.g., emacs-30.2.pdmp)
     # Using a relative symlink saves ~12MB compared to copying
-    target_triplet = Hardware::CPU.arm? ? "aarch64-unknown-linux-gnu" : "x86_64-pc-linux-gnu"
     pdmp_source = Dir.glob("#{staged_prefix}/libexec/emacs/#{emacs_version}/#{target_triplet}/*.pdmp").first
     if pdmp_source
       relative_path = "../libexec/emacs/#{emacs_version}/#{target_triplet}/#{File.basename(pdmp_source)}"

--- a/Casks/goland-linux.rb
+++ b/Casks/goland-linux.rb
@@ -1,6 +1,5 @@
 cask "goland-linux" do
-  arch intel: "",
-       arm:   "-aarch64"
+  arch arm: "-aarch64"
   os linux: "linux"
 
   version "2026.1.2,261.24374.154"

--- a/Casks/goland-linux.rb
+++ b/Casks/goland-linux.rb
@@ -3,8 +3,8 @@ cask "goland-linux" do
   os linux: "linux"
 
   version "2026.1.2,261.24374.154"
-  sha256 on_arch_conditional intel: "d4590311a6a9c836d33dee2ca0e7720872e4a7f513deb67ab221b21b28e6189a",
-                             arm:   "13c5a9038b3f78f10302ce3b20f0b4bf5d02d552a5f54614ed5357ff98a0a66e"
+  sha256 arm64_linux:  "13c5a9038b3f78f10302ce3b20f0b4bf5d02d552a5f54614ed5357ff98a0a66e",
+         x86_64_linux: "d4590311a6a9c836d33dee2ca0e7720872e4a7f513deb67ab221b21b28e6189a"
 
   url "https://download.jetbrains.com/go/goland-#{version.csv.first}#{arch}.tar.gz"
   name "GoLand"

--- a/Casks/intellij-idea-linux.rb
+++ b/Casks/intellij-idea-linux.rb
@@ -1,6 +1,5 @@
 cask "intellij-idea-linux" do
-  arch intel: "",
-       arm:   "-aarch64"
+  arch arm: "-aarch64"
   os linux: "linux"
 
   version "2026.1.2,261.24374.151"

--- a/Casks/intellij-idea-linux.rb
+++ b/Casks/intellij-idea-linux.rb
@@ -3,8 +3,8 @@ cask "intellij-idea-linux" do
   os linux: "linux"
 
   version "2026.1.2,261.24374.151"
-  sha256 on_arch_conditional intel: "e820175d1a7d0ee2492e7b38f6b7f046a132bfe4b082086d9b035edb03c777b1",
-                             arm:   "617739722b5b5453aaa5c0853fe1a2fb6e37cf7557529159c4c56aea40e083dd"
+  sha256 arm64_linux:  "617739722b5b5453aaa5c0853fe1a2fb6e37cf7557529159c4c56aea40e083dd",
+         x86_64_linux: "e820175d1a7d0ee2492e7b38f6b7f046a132bfe4b082086d9b035edb03c777b1"
 
   url "https://download.jetbrains.com/idea/ideaIU-#{version.csv.first}#{arch}.tar.gz"
   name "IntelliJ IDEA Ultimate"

--- a/Casks/opencode-desktop-linux.rb
+++ b/Casks/opencode-desktop-linux.rb
@@ -2,8 +2,8 @@ cask "opencode-desktop-linux" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "1.18.9"
-  sha256 on_arch_conditional intel: "19400e7ca2f101bf69056a5602241c406443fd3f32bfaee50170b0506f5f99d2",
-                             arm:   "6edcf2beb189ca230d9a03912eec91bdc9cf91b11e166e491f03f20c2a476724"
+  sha256 arm64_linux:  "6edcf2beb189ca230d9a03912eec91bdc9cf91b11e166e491f03f20c2a476724",
+         x86_64_linux: "19400e7ca2f101bf69056a5602241c406443fd3f32bfaee50170b0506f5f99d2"
 
   url "https://github.com/anomalyco/opencode/releases/download/v#{version}/opencode-desktop-linux-#{arch}.rpm",
       verified: "github.com/anomalyco/opencode/"

--- a/Casks/phpstorm-linux.rb
+++ b/Casks/phpstorm-linux.rb
@@ -1,6 +1,5 @@
 cask "phpstorm-linux" do
-  arch intel: "",
-       arm:   "-aarch64"
+  arch arm: "-aarch64"
   os linux: "linux"
 
   version "2026.1.2,261.24374.185"

--- a/Casks/phpstorm-linux.rb
+++ b/Casks/phpstorm-linux.rb
@@ -3,8 +3,8 @@ cask "phpstorm-linux" do
   os linux: "linux"
 
   version "2026.1.2,261.24374.185"
-  sha256 on_arch_conditional intel: "55b5ec7ca6a1a755f8030002d74560844f999314e1a2f9d81c7632be4393b457",
-                             arm:   "7f43b0baad0e8d5c27a781a3fdd8a23c59fd1751dfe209bf3301f391a6c81f6c"
+  sha256 arm64_linux:  "7f43b0baad0e8d5c27a781a3fdd8a23c59fd1751dfe209bf3301f391a6c81f6c",
+         x86_64_linux: "55b5ec7ca6a1a755f8030002d74560844f999314e1a2f9d81c7632be4393b457"
 
   url "https://download.jetbrains.com/webide/PhpStorm-#{version.csv.first}#{arch}.tar.gz"
   name "PhpStorm"

--- a/Casks/pycharm-linux.rb
+++ b/Casks/pycharm-linux.rb
@@ -3,8 +3,8 @@ cask "pycharm-linux" do
   os linux: "linux"
 
   version "2026.1.2,261.24374.152"
-  sha256 on_arch_conditional intel: "91c775be16fb0859f9b18ebd456d88e131cadf337b0ce9f9d8ed187886561966",
-                             arm:   "e6b4f25267afade04be6764f6bb16ea1d16159cae3490fbb4f58cc168ecffee3"
+  sha256 arm64_linux:  "e6b4f25267afade04be6764f6bb16ea1d16159cae3490fbb4f58cc168ecffee3",
+         x86_64_linux: "91c775be16fb0859f9b18ebd456d88e131cadf337b0ce9f9d8ed187886561966"
 
   url "https://download.jetbrains.com/python/pycharm-#{version.csv.first}#{arch}.tar.gz"
   name "PyCharm"

--- a/Casks/pycharm-linux.rb
+++ b/Casks/pycharm-linux.rb
@@ -1,6 +1,5 @@
 cask "pycharm-linux" do
-  arch intel: "",
-       arm:   "-aarch64"
+  arch arm: "-aarch64"
   os linux: "linux"
 
   version "2026.1.2,261.24374.152"

--- a/Casks/rancher-desktop-linux.rb
+++ b/Casks/rancher-desktop-linux.rb
@@ -7,7 +7,6 @@ cask "rancher-desktop-linux" do
   desc "Container management and Kubernetes on the desktop"
   homepage "https://rancherdesktop.io/"
 
-  auto_updates true
   depends_on formula: "squashfs"
 
   binary "squashfs-root/AppRun", target: "rancher-desktop"

--- a/Casks/rider-linux.rb
+++ b/Casks/rider-linux.rb
@@ -3,8 +3,8 @@ cask "rider-linux" do
   os linux: "linux"
 
   version "2026.1.2,261.24374.190"
-  sha256 on_arch_conditional intel: "3a6cac6865c6331c4001adaaac7bd7f325c8c092d4eed286f3f1011a1af9e440",
-                             arm:   "c5cc1de0e8286cc5c54365be48de8ee48de6b9de2479d550ff4ad90566d72066"
+  sha256 arm64_linux:  "c5cc1de0e8286cc5c54365be48de8ee48de6b9de2479d550ff4ad90566d72066",
+         x86_64_linux: "3a6cac6865c6331c4001adaaac7bd7f325c8c092d4eed286f3f1011a1af9e440"
 
   url "https://download.jetbrains.com/rider/JetBrains.Rider-#{version.csv.first}#{arch}.tar.gz"
   name "Rider"

--- a/Casks/rider-linux.rb
+++ b/Casks/rider-linux.rb
@@ -1,6 +1,5 @@
 cask "rider-linux" do
-  arch intel: "",
-       arm:   "-aarch64"
+  arch arm: "-aarch64"
   os linux: "linux"
 
   version "2026.1.2,261.24374.190"

--- a/Casks/rubymine-linux.rb
+++ b/Casks/rubymine-linux.rb
@@ -3,8 +3,8 @@ cask "rubymine-linux" do
   os linux: "linux"
 
   version "2026.1.2,261.24374.145"
-  sha256 on_arch_conditional intel: "eabbed2b54ec66cbae56a7f26bd7a1edf1e4ecb272cb1838498ad4ff25e72b52",
-                             arm:   "12f2a9637cdb5074f4dc65484ff1c9c5590eb4982c086fa360d70a7e25f49932"
+  sha256 arm64_linux:  "12f2a9637cdb5074f4dc65484ff1c9c5590eb4982c086fa360d70a7e25f49932",
+         x86_64_linux: "eabbed2b54ec66cbae56a7f26bd7a1edf1e4ecb272cb1838498ad4ff25e72b52"
 
   url "https://download.jetbrains.com/ruby/RubyMine-#{version.csv.first}#{arch}.tar.gz"
   name "RubyMine"

--- a/Casks/rubymine-linux.rb
+++ b/Casks/rubymine-linux.rb
@@ -1,6 +1,5 @@
 cask "rubymine-linux" do
-  arch intel: "",
-       arm:   "-aarch64"
+  arch arm: "-aarch64"
   os linux: "linux"
 
   version "2026.1.2,261.24374.145"

--- a/Casks/rustrover-linux.rb
+++ b/Casks/rustrover-linux.rb
@@ -1,6 +1,5 @@
 cask "rustrover-linux" do
-  arch intel: "",
-       arm:   "-aarch64"
+  arch arm: "-aarch64"
   os linux: "linux"
 
   version "2026.1.2,261.24374.182"

--- a/Casks/rustrover-linux.rb
+++ b/Casks/rustrover-linux.rb
@@ -3,8 +3,8 @@ cask "rustrover-linux" do
   os linux: "linux"
 
   version "2026.1.2,261.24374.182"
-  sha256 on_arch_conditional intel: "20d233ee719aaffa0787e0877f3e239b9b7dfc044f70c7e99ce97df59de48372",
-                             arm:   "3e608360cf27ab24909ba72950943d3f2cd290a391e95dcbb979d8a44d22edf5"
+  sha256 arm64_linux:  "3e608360cf27ab24909ba72950943d3f2cd290a391e95dcbb979d8a44d22edf5",
+         x86_64_linux: "20d233ee719aaffa0787e0877f3e239b9b7dfc044f70c7e99ce97df59de48372"
 
   url "https://download.jetbrains.com/rustrover/RustRover-#{version.csv.first}#{arch}.tar.gz"
   name "RustRover"

--- a/Casks/webstorm-linux.rb
+++ b/Casks/webstorm-linux.rb
@@ -1,6 +1,5 @@
 cask "webstorm-linux" do
-  arch intel: "",
-       arm:   "-aarch64"
+  arch arm: "-aarch64"
   os linux: "linux"
 
   version "2026.1.2,261.24374.125"

--- a/Casks/webstorm-linux.rb
+++ b/Casks/webstorm-linux.rb
@@ -3,8 +3,8 @@ cask "webstorm-linux" do
   os linux: "linux"
 
   version "2026.1.2,261.24374.125"
-  sha256 on_arch_conditional intel: "c6830e2d84ae5aa59487944b2354383a702018ceada910d677556850b5f5ef21",
-                             arm:   "41ef72725423f7bd632bc57648be460253698147d3c0ffcf4b620bbf62f286e1"
+  sha256 arm64_linux:  "41ef72725423f7bd632bc57648be460253698147d3c0ffcf4b620bbf62f286e1",
+         x86_64_linux: "c6830e2d84ae5aa59487944b2354383a702018ceada910d677556850b5f5ef21"
 
   url "https://download.jetbrains.com/webstorm/WebStorm-#{version.csv.first}#{arch}.tar.gz"
   name "WebStorm"

--- a/Formula/antigravity-sdk.rb
+++ b/Formula/antigravity-sdk.rb
@@ -5,6 +5,14 @@ class AntigravitySdk < Formula
   version "0.1.0"
   license "Apache-2.0"
 
+  # This formula tracks a git branch rather than a released tarball, so there is
+  # no version for `brew bump` to move to. Without this it fails every nightly run
+  # with "the current URL requires specifying a `--revision=` argument".
+  # `no_autobump!` is not usable here: it raises outside official Homebrew taps.
+  livecheck do
+    skip "Tracks the main branch; no tagged releases to bump to"
+  end
+
   depends_on "python@3.12"
 
   def install


### PR DESCRIPTION
## Summary

Bump PRs stopped reaching `main` on their own. The chain is Homebrew Bump, then Automerge, which dispatches Bump CI, which labels `pr-pull`, which runs publish.yml. Bump CI has 0 successes in its last 100 runs, so the label is never applied and publish.yml has not run since 2026-05-07. Every merge since then has been manual, and no merged PR carries the `pr-pull` label. Four bump PRs (#506, #508, #509, #510) were sitting green and unmergeable-by-automation for up to two days, and separately `brew bump` was failing on 15 packages every night.

1. **Cleared the tap-wide style and audit debt that was failing Bump CI.** Bump CI runs `brew test-bot --only-tap-syntax` without `--stable`, which styles and audits the whole tap rather than just running `readall`. 16 style offenses and one audit failure in casks unrelated to any bump were failing it on every run. Two of the `brew style --fix` autocorrections are behaviour changes, so they were not taken as-is: the `NoFileutilsRmrf` cop rewrites `rm_f` to a bare `rm` without adding `force:`, which would raise `Errno::ENOENT` on uninstall, and the `Cask/Variables` cop moved `on_arch_conditional` inside a `preflight` block, where it would raise `NoMethodError` at install time because `OnSystem::MacOSAndLinux` is included in `Cask::DSL` and not in the `Cask::DSL::Base` subclass flight blocks are instance_eval'd against.

2. **Scoped Bump CI's style check to changed files, matching tests.yml.** This is why the PR check was green while Bump CI was red on the identical commit: tests.yml uses `--only-tap-syntax --stable` plus `brew style` on the PR's own files. Point 1 unblocks promotion now, this stops the next unrelated offense from severing it again.

3. **Made the pipeline report failure instead of green.** Three separate paths were lying. bump.yml swallowed `brew bump` failures via `continue-on-error`, automerge.yml fired a workflow_dispatch at Bump CI and never looked at the result, and automerge.yml then gated on Homebrew Bump concluding `success`, which the swallowed failure guaranteed. Bump CI is now called as a reusable workflow from a matrix so its result is a real job result, `brew bump` failures re-raise after the reporting steps run, and Automerge proceeds on any non-cancelled conclusion since a partial bump still produces good PRs.

4. **Pinned the PR head SHA through test, label and pr-pull.** Bump CI stored `PR_REF` and never read it back, and wrote the value with literal quotes baked in, so nothing tied the commit that was tested to the commit that got promoted. The head SHA is now resolved before checkout, re-checked before labelling (applying `pr-pull` is what triggers a push to `main`), and passed to `brew pr-pull --head-sha`.

5. **Fixed the 15 packages that could not autobump.** 13 casks declared checksums as `sha256 on_arch_conditional intel:, arm:`, where the stanza argument is a send node, and `Utils::AST::CaskAST#replace_stanza_value` only matches a HashNode among the stanza arguments, so `bump-cask-pr` raised "Could not find 'sha256' stanza". They now use `sha256 arm64_linux:, x86_64_linux:`, which is both a plain hash and the correct keys for Linux casks, since `Cask::DSL#sha256` maps `arm:`/`intel:` to macOS only. emacs-app-linux already used this form and was the one multi-arch cask that bumped successfully. antigravity-sdk tracks a git branch with a hand-written version and gets a livecheck skip, as `no_autobump!` raises outside official Homebrew taps. bluefin-cli was failing audit with "Can't find dependency 'go'" because this job hand-rolls the Homebrew install and never taps homebrew/core, so core is now tapped explicitly.

6. **Added concurrency groups** to bump.yml, automerge.yml and bump-ci.yml so the daily cron and manual runs cannot pile up.

**Verified:** locally, `brew style`, `brew readall --aliases --os=all --arch=all` and `brew audit --except=installed --tap` are all clean, and `brew bump --tap ublue-os/experimental-tap` exits 0 with no errors across the whole tap (it previously errored on 15 packages). `brew test-bot --only-tap-syntax` passes on this branch both with and without `--stable`, so the strict form Bump CI used to run would now pass too. actionlint with shellcheck is clean on all workflows. The sha256 stanza fix was confirmed directly against the AST path `bump-cask-pr` uses: `replace_stanza_value` returns 0 replacements on the old form and 1 on the new. The `preflight` regression was confirmed the same way, an `instance_eval` against a `Cask::DSL::Base`-shaped object raises `NoMethodError` for `on_arch_conditional` while closed-over locals survive.

**Still needs a real run:** the reusable-workflow matrix in automerge.yml, the head-SHA guard, and the homebrew/core tap fix for bluefin-cli cannot be exercised locally. The canary is to dispatch Bump CI by hand against the next bump PR and confirm it labels `pr-pull`, publish.yml runs, `main` gets the commit and the branch is deleted, before letting the 03:00 cron drive it.

Related: #506, #508, #509, #510 were merged manually ahead of this branch so it starts from current `main`.
