### PR TITLE
fix(bump-ci): do not detach HEAD, it breaks brew test-bot --only-formulae

### DIFF
--- a/.github/workflows/bump-ci.yml
+++ b/.github/workflows/bump-ci.yml
@@ -43,9 +43,15 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Pin the SHA up front and test exactly that commit. Previously this stored
-      # PR_REF (with literal quotes baked into the value) and never read it back,
-      # so a push landing mid-run was tested at one SHA and promoted at another.
+      # Pin the SHA up front and assert the checkout landed on it. Previously this
+      # stored PR_REF (with literal quotes baked into the value) and never read it
+      # back, so a push landing mid-run was tested at one SHA and promoted at another.
+      #
+      # Do not detach here. `brew test-bot --only-formulae` derives its test range
+      # from the current branch and its upstream, so on a detached HEAD it aborts
+      # with "Did not find any formulae or commits to test!". `gh pr checkout`
+      # leaves a tracking branch, which is what test-bot needs; comparing its
+      # resulting SHA to headRefOid gives the same guarantee without detaching.
       - name: Check out the PR head SHA
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -54,7 +60,13 @@ jobs:
             --repo "${{ github.repository }}" --json headRefOid --jq .headRefOid)"
           echo "Testing PR #${{ inputs.pr_number }} at $head_sha"
           gh pr checkout "${{ inputs.pr_number }}"
-          git checkout --quiet --detach "$head_sha"
+
+          checked_out="$(git rev-parse HEAD)"
+          if [ "$checked_out" != "$head_sha" ]; then
+            echo "::error::Checked out $checked_out but PR #${{ inputs.pr_number }} head is $head_sha; aborting."
+            exit 1
+          fi
+
           echo "PR_HEAD_SHA=$head_sha" >> "$GITHUB_ENV"
 
       - name: Cache Homebrew Bundler RubyGems


### PR DESCRIPTION
## Summary

The head-SHA pinning in #514 broke `brew test-bot --only-formulae`. The first real Automerge run after that merge fanned out correctly to #515 and #516, and both legs failed with `Invalid usage: Did not find any formulae or commits to test!`.

The cause is `git checkout --detach` running after `gh pr checkout`. test-bot's FormulaeDetect derives its test range from the current branch and its upstream, so on a detached HEAD there is nothing for it to diff against. tests.yml passed on #516's branch with the same `--only-formulae` command, which is what isolated the difference to the detach.

**Fix:** keep the tracking branch `gh pr checkout` creates, and assert its resulting SHA equals `headRefOid` rather than detaching onto it. That keeps the guarantee that CI tested the commit it is about to label, and the existing re-check before applying `pr-pull` still closes the window against a push landing mid-run.

**Verified:** actionlint with shellcheck is clean. The real check is the next Automerge run reaching the `pr-pull` label, which needs this on main first.

**Note, unrelated to this PR:** bump PRs opened by the cron are still gated behind "approve workflow run". That is because `bump.yml` opens them with `secrets.GITHUB_TOKEN`; PRs opened with a GitHub App installation token are not gated, which is why renovate's PRs from `ubot-7274[bot]` run at attempt 1 while every `github-actions[bot]` bump PR lands on `conclusion=action_required`. Fixing that needs an App token or PAT in secrets and is tracked separately.

Related: #514