### PR TITLE
fix(bump-ci): pass formula names to test-bot, it has no PR context

### DIFF
--- a/.github/workflows/bump-ci.yml
+++ b/.github/workflows/bump-ci.yml
@@ -85,20 +85,63 @@ jobs:
       # scoped to the files this PR actually touches instead, matching tests.yml.
       - run: brew test-bot --only-tap-syntax --stable
 
-      - name: Style changed tap files
+      - name: Detect changed tap files
+        id: changed
         run: |
           git fetch --quiet origin main
           base="$(git merge-base origin/main HEAD)"
           changed_files="$(git diff --name-only --diff-filter=ACMR "$base...HEAD" -- Formula Casks)"
-          if [ -n "$changed_files" ]; then
-            echo "Styling: $changed_files"
+
+          # Fully qualify formula names so a same-named core formula cannot win.
+          tap="${GITHUB_REPOSITORY/homebrew-/}"
+          formulae="$(echo "$changed_files" | sed -n "s|^Formula/\(.*\)\.rb$|$tap/\1|p" | tr '\n' ' ')"
+
+          echo "Changed files: ${changed_files:-none}"
+          echo "Changed formulae: ${formulae:-none}"
+
+          {
+            echo "files<<CHANGED_EOF"
+            echo "$changed_files"
+            echo "CHANGED_EOF"
+            echo "formulae=$formulae"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Style changed tap files
+        env:
+          CHANGED_FILES: ${{ steps.changed.outputs.files }}
+        run: |
+          if [ -n "$CHANGED_FILES" ]; then
             # shellcheck disable=SC2086
-            brew style $changed_files
+            brew style $CHANGED_FILES
           else
             echo "No Formula or Casks changes to style."
           fi
 
-      - run: brew test-bot --only-formulae
+      # test-bot derives its diff range from GITHUB_BASE_REF, which GitHub only sets
+      # for `pull_request` events. Under workflow_call/workflow_dispatch there is no
+      # PR context, so it falls through to the branch-job path where
+      # diff_start_sha1 == diff_end_sha1 == GITHUB_SHA (main), producing an empty
+      # range and "Invalid usage: Did not find any formulae or commits to test!".
+      # Passing formula names explicitly sets @testing_formulae and skips the diff
+      # entirely (Homebrew test_bot/formulae_detect.rb:67).
+      #
+      # Casks cannot be passed this way (formulae_detect.rb:74 raises on a
+      # non-formula argument) and --only-formulae does nothing for them regardless,
+      # so cask-only bumps skip this step.
+      - name: Test changed formulae
+        env:
+          CHANGED_FORMULAE: ${{ steps.changed.outputs.formulae }}
+        run: |
+          if [ -z "$CHANGED_FORMULAE" ]; then
+            echo "No formula changes in this PR; skipping --only-formulae."
+            exit 0
+          fi
+
+          for formula in $CHANGED_FORMULAE; do
+            echo "::group::brew test-bot --only-formulae $formula"
+            brew test-bot --only-formulae "$formula"
+            echo "::endgroup::"
+          done
 
       # Applying `pr-pull` triggers publish.yml, which pushes to main. Only do that
       # if the head is still the commit that was just tested.


### PR DESCRIPTION
## Summary

`brew test-bot --only-formulae` still fails in Bump CI after #517. Different cause, and an older one: it was masked for months because tap-syntax failed first, so `--only-formulae` never got to run.

test-bot derives its diff range from `GITHUB_BASE_REF`, which GitHub sets only for `pull_request` events. Bump CI runs under `workflow_call`/`workflow_dispatch`, so there is no PR context and it falls through to the branch-job path at `test_bot/formulae_detect.rb:109`, where `diff_start_sha1` and `diff_end_sha1` are both `GITHUB_SHA` (main).

The canary run against #516 shows it exactly:

```
tap origin/main   658fa49
HEAD              2b9d65f (rocm-smi-lib 7.2.4)
diff_start_sha1   658fa493...
diff_end_sha1     658fa493...
```

An empty range, then `Invalid usage: Did not find any formulae or commits to test!`.

**Fix:** pass the changed formula names as arguments. That sets `@testing_formulae` directly and skips the diff (`formulae_detect.rb:67`). Names are fully qualified with the tap so a same-named core formula cannot win, which matters here since `rocm-smi-lib` also exists in homebrew-core.

Casks cannot be passed this way (`formulae_detect.rb:74` raises on any argument that is not a resolvable formula) and `--only-formulae` does nothing for casks regardless, so cask-only bumps now skip the step instead of failing on it.

Also hoists changed-file detection into its own step so styling and formula testing share one diff, and passes values through `env` rather than interpolating them into the script body.

**Verified:** actionlint with shellcheck is clean, and the tap-name and formula-name derivation was checked against a representative file list. The real proof is the next Bump CI run against #516 reaching the `pr-pull` label.

**Worth considering separately:** `tests.yml` already runs the full test-bot suite on every PR as a `pull_request` event, on both x86 and arm, and it works. Bump CI re-running it is what keeps producing this class of bug. A simpler design is for Bump CI to verify the PR's existing `test-bot` check runs are green at the pinned SHA and then label, rather than re-testing. That depends on those checks actually having run, which is currently blocked by the `GITHUB_TOKEN` approval gate described in #517.

Related: #514, #517