### PR TITLE
fix(publish): call pr-pull directly instead of via the label event

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -59,8 +59,12 @@ jobs:
     uses: ./.github/workflows/bump-ci.yml
     with:
       pr_number: ${{ matrix.pr }}
+    # contents: write is required because bump-ci.yml now calls publish.yml, which
+    # pushes the promoted commit to main. A called workflow cannot exceed the
+    # permissions granted here.
     permissions:
-      contents: read
+      contents: write
       actions: read
       checks: read
+      issues: read
       pull-requests: write

--- a/.github/workflows/bump-ci.yml
+++ b/.github/workflows/bump-ci.yml
@@ -143,8 +143,9 @@ jobs:
             echo "::endgroup::"
           done
 
-      # Applying `pr-pull` triggers publish.yml, which pushes to main. Only do that
-      # if the head is still the commit that was just tested.
+      # The `promote` job below is what actually runs pr-pull; this label is kept as
+      # a visible marker of what passed. Guard it anyway, since a human seeing the
+      # label may hand-trigger publish.yml, which pushes to main.
       - name: Label PR on Success
         if: success()
         env:
@@ -160,3 +161,20 @@ jobs:
 
           gh pr edit "${{ inputs.pr_number }}" --add-label "pr-pull"
           echo "Labelled PR #${{ inputs.pr_number }} pr-pull at $PR_HEAD_SHA"
+
+  # Call publish.yml rather than depending on the `labeled` event it also listens
+  # for. Bump CI applies that label with GITHUB_TOKEN, and GitHub does not start
+  # new workflow runs from GITHUB_TOKEN-triggered events, so the event path never
+  # fires for the automated flow. Verified on #516: the label landed at 18:06:16
+  # and publish.yml did not run.
+  promote:
+    needs: test-and-label
+    uses: ./.github/workflows/publish.yml
+    with:
+      pr_number: ${{ inputs.pr_number }}
+    permissions:
+      actions: read
+      checks: read
+      contents: write
+      issues: read
+      pull-requests: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,13 +1,24 @@
 name: brew pr-pull
 
 on:
+  # Kept so a human can still promote by hand-applying the `pr-pull` label.
   pull_request_target:
     types:
       - labeled
+  # Called directly by bump-ci.yml. The automated path cannot rely on the label
+  # event: Bump CI applies the label with GITHUB_TOKEN, and GitHub does not start
+  # new workflow runs from events triggered by GITHUB_TOKEN, so the `labeled`
+  # event never reaches this workflow. Calling it removes that dependency.
+  workflow_call:
+    inputs:
+      pr_number:
+        description: "Pull Request Number"
+        required: true
+        type: string
 
 jobs:
   pr-pull:
-    if: contains(github.event.pull_request.labels.*.name, 'pr-pull')
+    if: github.event_name != 'pull_request_target' || contains(github.event.pull_request.labels.*.name, 'pr-pull')
     runs-on: ubuntu-24.04
     env:
       HOMEBREW_NO_REQUIRE_TAP_TRUST: "1"
@@ -26,13 +37,34 @@ jobs:
       - name: Set up git
         uses: Homebrew/actions/git-user-config@13f73d7cbd2f8f180d85d8f7201698cf110bf84c # main
 
+      # The two triggers carry different payloads, so resolve the PR once here and
+      # let every step below read the same values.
+      - name: Resolve pull request
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
+        run: |
+          data="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --json number,headRefName,headRefOid,isCrossRepository)"
+
+          {
+            echo "number=$(echo "$data" | jq -r .number)"
+            echo "head_sha=$(echo "$data" | jq -r .headRefOid)"
+            echo "head_ref=$(echo "$data" | jq -r .headRefName)"
+            echo "fork=$(echo "$data" | jq -r .isCrossRepository)"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Promoting PR #$PR_NUMBER"
+          echo "$data"
+
       # --head-sha makes pr-pull refuse to promote anything other than the commit
-      # that carried the label, closing the window between labelling and pulling.
+      # that was resolved above, closing the window between testing and pulling.
       - name: Pull bottles
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PULL_REQUEST: ${{ github.event.pull_request.number }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PULL_REQUEST: ${{ steps.pr.outputs.number }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
         run: brew pr-pull --debug --tap="$GITHUB_REPOSITORY" --head-sha="$HEAD_SHA" "$PULL_REQUEST"
 
       - name: Push commits
@@ -41,7 +73,7 @@ jobs:
           branch: main
 
       - name: Delete branch
-        if: github.event.pull_request.head.repo.fork == false
+        if: steps.pr.outputs.fork == 'false'
         env:
-          BRANCH: ${{ github.event.pull_request.head.ref }}
+          BRANCH: ${{ steps.pr.outputs.head_ref }}
         run: git push --delete origin "$BRANCH"


### PR DESCRIPTION
## Summary

The canary against #516 got all the way to a green Bump CI and an applied `pr-pull` label, then stopped dead. The label landed at 18:06:16 by `github-actions[bot]`, and publish.yml never ran. Its last run is still 2026-05-07.

GitHub does not start new workflow runs from events triggered by `GITHUB_TOKEN`. Bump CI applies the label with `GITHUB_TOKEN`, so the `labeled` event publish.yml listens for is never delivered. No amount of fixing Bump CI completes the chain while promotion depends on that event, which is why #514, #517 and #518 each got one step further and then stopped.

**Fix:** add a `workflow_call` trigger to publish.yml and call it from a `promote` job in bump-ci.yml, so the automated path does not depend on an event at all. The `pull_request_target`/`labeled` trigger stays for humans promoting by hand, and Bump CI still applies the label as a visible marker of what passed.

The two triggers carry different payloads, so the PR number, head SHA, head ref and fork flag are resolved once via `gh` and every step reads those, rather than `github.event.pull_request.*`.

automerge.yml now needs `contents: write`, because a called workflow cannot exceed the permissions its caller grants and publish.yml pushes to main.

**Why this shape:** the alternative is a PAT or App installation token for the label call, which needs a secret this repo does not have and which I cannot add. This approach needs no new credential and no admin.

**Verified:** actionlint with shellcheck is clean across all workflows. The real proof is the next Bump CI run against #516 reaching main and deleting the branch, which needs this merged first.

**Still open, unchanged by this PR:** bump PRs opened by the cron are gated behind "approve workflow run" because `bump.yml` opens them with `GITHUB_TOKEN`. That is now cosmetic rather than blocking, since promotion no longer depends on those `pull_request` runs.

Related: #514, #517, #518