### PR TITLE
ci(bump): squash-merge cask bumps instead of running pr-pull on them

### DIFF
--- a/.github/workflows/bump-ci.yml
+++ b/.github/workflows/bump-ci.yml
@@ -21,6 +21,10 @@ concurrency:
 
 jobs:
   test-and-label:
+    outputs:
+      # Empty when the PR touches no Formula/, i.e. a cask-only bump.
+      formulae: ${{ steps.changed.outputs.formulae }}
+      head_sha: ${{ steps.checkout.outputs.head_sha }}
     env:
       # test-bot writes tap trust under its temporary HOME. If XDG_CONFIG_HOME is set,
       # nested `brew` commands ignore that trust store and `brew doctor` reports this
@@ -53,6 +57,7 @@ jobs:
       # leaves a tracking branch, which is what test-bot needs; comparing its
       # resulting SHA to headRefOid gives the same guarantee without detaching.
       - name: Check out the PR head SHA
+        id: checkout
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -68,6 +73,7 @@ jobs:
           fi
 
           echo "PR_HEAD_SHA=$head_sha" >> "$GITHUB_ENV"
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
 
       - name: Cache Homebrew Bundler RubyGems
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
@@ -162,6 +168,9 @@ jobs:
           gh pr edit "${{ inputs.pr_number }}" --add-label "pr-pull"
           echo "Labelled PR #${{ inputs.pr_number }} pr-pull at $PR_HEAD_SHA"
 
+  # Formula bumps go through `brew pr-pull`, which is what fetches the bottles
+  # tests.yml built and commits them alongside the version bump.
+  #
   # Call publish.yml rather than depending on the `labeled` event it also listens
   # for. Bump CI applies that label with GITHUB_TOKEN, and GitHub does not start
   # new workflow runs from GITHUB_TOKEN-triggered events, so the event path never
@@ -169,6 +178,7 @@ jobs:
   # and publish.yml did not run.
   promote:
     needs: test-and-label
+    if: needs.test-and-label.outputs.formulae != ''
     uses: ./.github/workflows/publish.yml
     with:
       pr_number: ${{ inputs.pr_number }}
@@ -178,3 +188,32 @@ jobs:
       contents: write
       issues: read
       pull-requests: write
+
+  # Cask bumps have no bottles, so pr-pull buys nothing and costs the PR linkage:
+  # it cherry-picks and closes the PR, leaving it CLOSED rather than MERGED and
+  # dropping the "(#NNN)" suffix every hand-merged cask bump in this tap carries.
+  # Squash-merge them instead, matching the repository's existing history.
+  merge-cask:
+    needs: test-and-label
+    if: needs.test-and-label.outputs.formulae == ''
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Squash merge cask bump
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          EXPECTED_SHA: ${{ needs.test-and-label.outputs.head_sha }}
+        run: |
+          current_sha="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --json headRefOid --jq .headRefOid)"
+
+          if [ "$current_sha" != "$EXPECTED_SHA" ]; then
+            echo "::error::PR #$PR_NUMBER head moved from $EXPECTED_SHA to $current_sha after testing; refusing to merge."
+            exit 1
+          fi
+
+          gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --squash --delete-branch
+          echo "Squash-merged cask bump PR #$PR_NUMBER at $EXPECTED_SHA"


### PR DESCRIPTION
## Summary

`brew pr-pull` exists to fetch the bottles tests.yml built and commit them alongside the version bump. Casks have no bottles, so for them it degrades to cherry-pick, push, close, delete branch, and costs the PR linkage. Last night's automated cask bump landed as:

```
a3811dc8  chatgpt-linux 26.810.50856          <- pr-pull, PR #521 left CLOSED
b8f79317  chatgpt-linux 26.810.41047 (#509)   <- hand-merged, MERGED with backlink
```

Every hand-merged cask bump in this tap carries the `(#NNN)` suffix and a real Merged state. The automated ones no longer would.

This was the pre-existing intent rather than something #519 introduced: the original bump-ci.yml labelled every bump PR `pr-pull` with no cask/formula distinction, and publish.yml pr-pulls whatever carries the label. It simply never ran, so a cask never came out the far end until the pipeline started working.

**Fix:** route on whether the PR touches `Formula/`, which the `Detect changed tap files` step already computes, so the gating is essentially free.

- `formulae` non-empty → `promote`, calling publish.yml exactly as now
- `formulae` empty → `merge-cask`, `gh pr merge --squash --delete-branch`

A PR touching both takes the pr-pull path, since the bottles still matter.

`merge-cask` re-reads the head SHA and refuses to merge if it moved since testing, so it carries the same guarantee as the labelling step and publish.yml's `--head-sha`.

**Verified:** actionlint with shellcheck is clean. The routing expression was checked against a cask-only, a formula-only, and a mixed file list, giving squash, pr-pull and pr-pull respectively. The empty case matters most here, and it resolves to a genuinely empty string rather than a space, so `!= ''` gates correctly.

**Note:** the `pr-pull` label is still applied on success as a marker of what passed, and publish.yml keeps its `pull_request_target`/`labeled` trigger, so hand-promoting a cask with the label still works if you ever want pr-pull semantics for one.

Related: #519