### PR TITLE
fix(casks): declare depends_on linux so bump can resolve a checksum

### DIFF
--- a/Casks/chatgpt-linux.rb
+++ b/Casks/chatgpt-linux.rb
@@ -4,9 +4,7 @@ cask "chatgpt-linux" do
   os linux: "linux"
 
   version "26.810.50856"
-  sha256 arm:          "295aa2ba58108d74a89387e533ba776ab85509bc011eb4fd9dc07ec217f2a976",
-         intel:        "6480278aab012086df56f759c1825bc3c1cd3ce7dc9cd6d9bbf012d2ae38d9e6",
-         arm64_linux:  "295aa2ba58108d74a89387e533ba776ab85509bc011eb4fd9dc07ec217f2a976",
+  sha256 arm64_linux:  "295aa2ba58108d74a89387e533ba776ab85509bc011eb4fd9dc07ec217f2a976",
          x86_64_linux: "6480278aab012086df56f759c1825bc3c1cd3ce7dc9cd6d9bbf012d2ae38d9e6"
 
   url "https://persistent.oaistatic.com/codex-app-prod/linux/rpm/#{arch}/chatgpt-#{version}-1.#{arch}.rpm"
@@ -20,6 +18,7 @@ cask "chatgpt-linux" do
   end
 
   auto_updates true
+  depends_on linux: :any
   depends_on formula: "cpio"
   depends_on formula: "rpm2cpio"
 

--- a/Casks/clion-linux.rb
+++ b/Casks/clion-linux.rb
@@ -26,6 +26,7 @@ cask "clion-linux" do
 
   auto_updates false
   conflicts_with cask: "jetbrains-toolbox-linux"
+  depends_on linux: :any
 
   binary "#{HOMEBREW_PREFIX}/Caskroom/clion-linux/#{version}/clion-#{version.csv.first}/bin/clion"
   artifact "jetbrains-clion.desktop",

--- a/Casks/cursor-linux.rb
+++ b/Casks/cursor-linux.rb
@@ -23,6 +23,8 @@ cask "cursor-linux" do
     end
   end
 
+  depends_on linux: :any
+
   binary "Cursor-#{version.csv.first}-#{file_arch}.AppImage", target: "cursor"
   bash_completion "#{staged_path}/squashfs-root/usr/share/cursor/resources/completions/bash/cursor"
   zsh_completion  "#{staged_path}/squashfs-root/usr/share/cursor/resources/completions/zsh/_cursor"

--- a/Casks/datagrip-linux.rb
+++ b/Casks/datagrip-linux.rb
@@ -26,6 +26,7 @@ cask "datagrip-linux" do
 
   auto_updates false
   conflicts_with cask: "jetbrains-toolbox-linux"
+  depends_on linux: :any
 
   binary "#{HOMEBREW_PREFIX}/Caskroom/datagrip-linux/#{version}/DataGrip-#{version.csv.first}/bin/datagrip"
   artifact "jetbrains-datagrip.desktop",

--- a/Casks/dataspell-linux.rb
+++ b/Casks/dataspell-linux.rb
@@ -26,6 +26,7 @@ cask "dataspell-linux" do
 
   auto_updates false
   conflicts_with cask: "jetbrains-toolbox-linux"
+  depends_on linux: :any
 
   binary "#{HOMEBREW_PREFIX}/Caskroom/dataspell-linux/#{version}/dataspell-#{version.csv.first}/bin/dataspell"
   artifact "jetbrains-dataspell.desktop",

--- a/Casks/emacs-app-linux.rb
+++ b/Casks/emacs-app-linux.rb
@@ -21,6 +21,7 @@ cask "emacs-app-linux" do
     regex(/^emacs-pgtk[._-]v?(\d+(?:\.\d+)+-\d+)$/i)
   end
 
+  depends_on linux: :any
   depends_on formula: "libgccjit"
   depends_on formula: "tree-sitter@0.25"
 

--- a/Casks/goland-linux.rb
+++ b/Casks/goland-linux.rb
@@ -26,6 +26,7 @@ cask "goland-linux" do
 
   auto_updates false
   conflicts_with cask: "jetbrains-toolbox-linux"
+  depends_on linux: :any
 
   binary "#{HOMEBREW_PREFIX}/Caskroom/goland-linux/#{version}/GoLand-#{version.csv.first}/bin/goland"
   artifact "jetbrains-goland.desktop",

--- a/Casks/intellij-idea-linux.rb
+++ b/Casks/intellij-idea-linux.rb
@@ -26,6 +26,7 @@ cask "intellij-idea-linux" do
 
   auto_updates false
   conflicts_with cask: "jetbrains-toolbox-linux"
+  depends_on linux: :any
 
   binary "#{HOMEBREW_PREFIX}/Caskroom/intellij-idea-linux/#{version}/idea-IU-#{version.csv.second}/bin/idea"
   artifact "jetbrains-idea.desktop",

--- a/Casks/opencode-desktop-linux.rb
+++ b/Casks/opencode-desktop-linux.rb
@@ -18,6 +18,7 @@ cask "opencode-desktop-linux" do
     end
   end
 
+  depends_on linux: :any
   depends_on formula: "gtk+3"
   depends_on formula: "rpm2cpio"
   depends_on formula: "cpio"

--- a/Casks/phpstorm-linux.rb
+++ b/Casks/phpstorm-linux.rb
@@ -26,6 +26,7 @@ cask "phpstorm-linux" do
 
   auto_updates false
   conflicts_with cask: "jetbrains-toolbox-linux"
+  depends_on linux: :any
 
   binary "#{HOMEBREW_PREFIX}/Caskroom/phpstorm-linux/#{version}/PhpStorm-#{version.csv.second}/bin/phpstorm"
   artifact "jetbrains-phpstorm.desktop",

--- a/Casks/pycharm-linux.rb
+++ b/Casks/pycharm-linux.rb
@@ -26,6 +26,7 @@ cask "pycharm-linux" do
 
   auto_updates false
   conflicts_with cask: "jetbrains-toolbox-linux"
+  depends_on linux: :any
 
   binary "#{HOMEBREW_PREFIX}/Caskroom/pycharm-linux/#{version}/pycharm-#{version.csv.first}/bin/pycharm"
   artifact "jetbrains-pycharm.desktop",

--- a/Casks/rider-linux.rb
+++ b/Casks/rider-linux.rb
@@ -26,6 +26,7 @@ cask "rider-linux" do
 
   auto_updates false
   conflicts_with cask: "jetbrains-toolbox-linux"
+  depends_on linux: :any
 
   binary "#{HOMEBREW_PREFIX}/Caskroom/rider-linux/#{version}/JetBrains Rider-#{version.csv.first}/bin/rider"
   artifact "jetbrains-rider.desktop",

--- a/Casks/rubymine-linux.rb
+++ b/Casks/rubymine-linux.rb
@@ -26,6 +26,7 @@ cask "rubymine-linux" do
 
   auto_updates false
   conflicts_with cask: "jetbrains-toolbox-linux"
+  depends_on linux: :any
 
   binary "#{HOMEBREW_PREFIX}/Caskroom/rubymine-linux/#{version}/RubyMine-#{version.csv.first}/bin/rubymine"
   artifact "jetbrains-rubymine.desktop",

--- a/Casks/rustrover-linux.rb
+++ b/Casks/rustrover-linux.rb
@@ -26,6 +26,7 @@ cask "rustrover-linux" do
 
   auto_updates false
   conflicts_with cask: "jetbrains-toolbox-linux"
+  depends_on linux: :any
 
   binary "#{HOMEBREW_PREFIX}/Caskroom/rustrover-linux/#{version}/RustRover-#{version.csv.first}/bin/rustrover"
   artifact "jetbrains-rustrover.desktop",

--- a/Casks/webstorm-linux.rb
+++ b/Casks/webstorm-linux.rb
@@ -26,6 +26,7 @@ cask "webstorm-linux" do
 
   auto_updates false
   conflicts_with cask: "jetbrains-toolbox-linux"
+  depends_on linux: :any
 
   binary "#{HOMEBREW_PREFIX}/Caskroom/webstorm-linux/#{version}/WebStorm-#{version.csv.second}/bin/webstorm"
   artifact "jetbrains-webstorm.desktop",


### PR DESCRIPTION
## Summary

opencode-desktop-linux is stuck at 1.18.9 while upstream is at 1.18.18. The livecheck is fine, it resolves `1.18.9 ==> 1.18.18`. The bump fails, and it is a regression from #514: the casks converted to `sha256 arm64_linux:/x86_64_linux:` now error with `Could not find 'sha256' stanza with value ""`.

`bump-cask-pr` resolves a checksum per supported (os, arch) pair, and skips macOS only when `supports_macos?` is false, which is `!depends_on.requires_linux?` in `cask/cask.rb:274`. The `os linux:` stanza is a string mapping like `arch`, not a `depends_on`, so the macOS pass still runs and finds nothing.

`depends_on linux: :any` sets that flag. emacs-app-linux is included, it was only spared by having no new version. chatgpt-linux also loses its duplicated macOS keys.

**Verified:** `bump-cask-pr --dry-run` now completes for opencode-desktop-linux and webstorm-linux. style, readall and audit clean.

**Note:** no cask in ublue-os/homebrew-tap uses `depends_on linux:`.

Related: #514
