### PR TITLE
fix(bluefin-cli): set version via ldflags so --version stops reporting dev

### DIFF
--- a/Formula/bluefin-cli.rb
+++ b/Formula/bluefin-cli.rb
@@ -22,7 +22,17 @@ class BluefinCli < Formula
 
   def install
     ENV["CGO_ENABLED"] = "0"
-    system "go", "build", *std_go_args(ldflags: "-s -w")
+    # Matches upstream .goreleaser.yaml. Without the -X flag the `version`
+    # variable in cmd/root.go keeps its "dev" default and `--version` reports
+    # "bluefin-cli version dev", which fails the test block below.
+    #
+    # Read the module path from go.mod rather than hardcoding it: upstream moved
+    # from github.com/hanthor/bluefin-cli to github.com/tuna-os/bluefin-cli
+    # between 0.6.4 and 0.10.7, and a stale path silently leaves version at "dev".
+    go_module = File.read(buildpath/"go.mod")[/^module\s+(\S+)/, 1]
+    odie "could not read module path from go.mod" if go_module.blank?
+
+    system "go", "build", *std_go_args(ldflags: "-X #{go_module}/cmd.version=#{version}")
   end
 
   test do


### PR DESCRIPTION
## Summary

bluefin-cli bumps have been failing their own test block, which is why #515 and #520 are both red:

```
Minitest::Assertion: Expected /0\.10\.7/ to match "bluefin-cli version dev\n".
```

`cmd/root.go` declares `version = "dev"` and upstream's `.goreleaser.yaml` overrides it at link time with `-X <module>/cmd.version=<version>`. Our formula passed only `-s -w`, so the default survived and `--version` reported dev.

The module path is read from go.mod rather than hardcoded. Upstream moved from github.com/hanthor/bluefin-cli to github.com/tuna-os/bluefin-cli between 0.6.4 and 0.10.7, and a stale path is silently ineffective, the `-X` just matches no symbol and version stays dev. I hit exactly that hardcoding tuna-os while building 0.6.4.

**Verified:** built 0.6.4 from source locally. The link line resolves to `-X github.com/hanthor/bluefin-cli/cmd.version=0.6.4` and the binary reports `bluefin-cli version 0.6.4`, where it reported dev before. `brew test` would not run in my local Homebrew because of an unrelated gem loading failure, so the assertion itself is verified against that output rather than through the harness.

Once this lands, #520 needs its branch updated to pick it up. #515 is superseded by #520 and can be closed.
