### PR TITLE
fix(bluefin-cli): derive upstream repo from formula in bottle workflow

### DIFF
--- a/.github/workflows/bottle-bluefin-cli.yml
+++ b/.github/workflows/bottle-bluefin-cli.yml
@@ -30,26 +30,37 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Read the upstream repo from the formula instead of hardcoding it:
+          # it has already moved once (hanthor -> tuna-os) and the stale
+          # hardcoded org broke every run after the transfer.
+          UPSTREAM_REPO=$(grep -oP '^  url "https://github.com/\K[^/]+/[^/]+(?=/archive/)' Formula/bluefin-cli.rb)
+          if [ -z "$UPSTREAM_REPO" ]; then
+            echo "Could not determine upstream repo from Formula/bluefin-cli.rb" >&2
+            exit 1
+          fi
+          echo "Upstream repo: ${UPSTREAM_REPO}"
+          echo "upstream_repo=${UPSTREAM_REPO}" >> "$GITHUB_OUTPUT"
+
           if [ -n "${{ github.event.client_payload.version || github.event.inputs.version }}" ]; then
             TARGET_INPUT="${{ github.event.client_payload.version || github.event.inputs.version }}"
             TARGET_TAG="${TARGET_INPUT#v}"
             echo "Checking manual version request: ${TARGET_TAG}"
           else
             echo "Checking for latest GitHub release..."
-            TARGET_TAG=$(gh release view --repo hanthor/bluefin-cli --json tagName --jq .tagName)
+            TARGET_TAG=$(gh release view --repo "$UPSTREAM_REPO" --json tagName --jq .tagName)
             TARGET_TAG="${TARGET_TAG#v}"
           fi
 
           echo "latest_version=${TARGET_TAG}" >> "$GITHUB_OUTPUT"
 
-          CURRENT_VERSION=$(grep -oP '^  url "https://github.com/hanthor/bluefin-cli/archive/refs/tags/v\K[^\"]+(?=\.tar\.gz")' Formula/bluefin-cli.rb)
+          CURRENT_VERSION=$(grep -oP '^  url "https://github.com/[^/]+/[^/]+/archive/refs/tags/v\K[^\"]+(?=\.tar\.gz")' Formula/bluefin-cli.rb)
           echo "current_version=${CURRENT_VERSION}" >> "$GITHUB_OUTPUT"
 
           if [ "$TARGET_TAG" != "$CURRENT_VERSION" ]; then
             echo "needs_update=true" >> "$GITHUB_OUTPUT"
             echo "Update needed: $CURRENT_VERSION -> $TARGET_TAG"
 
-            SOURCE_URL="https://github.com/hanthor/bluefin-cli/archive/refs/tags/v${TARGET_TAG}.tar.gz"
+            SOURCE_URL="https://github.com/${UPSTREAM_REPO}/archive/refs/tags/v${TARGET_TAG}.tar.gz"
             SOURCE_SHA=$(curl -fsSL "$SOURCE_URL" | sha256sum | awk '{print $1}')
             echo "source_sha=${SOURCE_SHA}" >> "$GITHUB_OUTPUT"
           else
@@ -68,8 +79,9 @@ jobs:
         run: |
           VERSION="${{ steps.check.outputs.latest_version }}"
           SOURCE_SHA="${{ steps.check.outputs.source_sha }}"
+          UPSTREAM_REPO="${{ steps.check.outputs.upstream_repo }}"
 
-          sed -i "s|^  url \".*\"|  url \"https://github.com/hanthor/bluefin-cli/archive/refs/tags/v${VERSION}.tar.gz\"|" Formula/bluefin-cli.rb
+          sed -i "s|^  url \".*\"|  url \"https://github.com/${UPSTREAM_REPO}/archive/refs/tags/v${VERSION}.tar.gz\"|" Formula/bluefin-cli.rb
           sed -i "s|^  sha256 \".*\"|  sha256 \"${SOURCE_SHA}\"|" Formula/bluefin-cli.rb
 
       - name: Create PR for formula update


### PR DESCRIPTION
## Summary

The bluefin-cli bottle workflow has silently failed on every run since the upstream repo moved from hanthor/bluefin-cli to tuna-os/bluefin-cli in June ([7502f5c](https://github.com/ublue-os/homebrew-experimental-tap/commit/7502f5c)). That is why the formula still carries the 0.6.4 bottle block while the source URL points at 0.10.7: no bottle has been built or attached since the transfer.

1. **The version-check grep hardcoded the old org.** It looked for `hanthor/bluefin-cli` in the formula's url line, matched nothing after the transfer, and exited 1 under `bash -e`, killing the update-formula job in under 10 seconds before any bottle build started. Every push and workflow_dispatch run since June 13 failed at this line.

2. **The workflow now reads the upstream owner/repo from the formula itself.** The check step extracts it from the url line once, exports it as a step output, and the release lookup, source tarball URL, sha computation, and formula-update sed all use it. If upstream moves orgs again, the workflow follows the formula instead of breaking.

3. **A missing match now fails loudly.** If the url line can't be parsed the step exits with a clear error message instead of dying on a bare grep.

Verified: both new grep patterns extract `tuna-os/bluefin-cli` and `0.10.7` from the current Formula/bluefin-cli.rb, and the YAML parses. The end-to-end path still needs a real run, after merge I'll dispatch the workflow for 0.10.7 to build and attach the bottles.
