### PR TITLE
fix(ghostty-linux): disable broken D-Bus activation so GUI launch works

### DIFF
--- a/Casks/ghostty-linux.rb
+++ b/Casks/ghostty-linux.rb
@@ -30,7 +30,6 @@ cask "ghostty-linux" do
 
     xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
     FileUtils.mkdir_p "#{xdg_data}/applications"
-    FileUtils.mkdir_p "#{xdg_data}/systemd/user"
 
     # Create wrapper script to execute AppRun from the correct directory
     # (upstream switched from binary AppRun to shell script in v1.2.3 which
@@ -46,10 +45,12 @@ cask "ghostty-linux" do
   postflight do
     xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
 
-    # keep the app-id filename (GNOME window matching) and the Exec arguments
+    # keep the app-id filename (GNOME window matching) and the Exec arguments;
+    # disable D-Bus activation since the bundled service file execs a CI path
     desktop_content = File.read("#{staged_path}/squashfs-root/com.mitchellh.ghostty.desktop")
     desktop_content.gsub!(/^TryExec=\S+/, "TryExec=#{HOMEBREW_PREFIX}/bin/ghostty")
     desktop_content.gsub!(/^Exec=\S+/, "Exec=#{HOMEBREW_PREFIX}/bin/ghostty")
+    desktop_content.gsub!(/^DBusActivatable=true$/, "DBusActivatable=false")
     File.write("#{xdg_data}/applications/com.mitchellh.ghostty.desktop", desktop_content)
 
     # install icons under the name the desktop file's Icon= key references
@@ -59,19 +60,23 @@ cask "ghostty-linux" do
       FileUtils.mkdir_p target_dir
       FileUtils.cp(icon, "#{target_dir}/com.mitchellh.ghostty.png")
     end
+    system "gtk-update-icon-cache", "-f", "-t", "#{xdg_data}/icons/hicolor"
 
-    FileUtils.cp("#{staged_path}/squashfs-root/share/dbus-1/services/com.mitchellh.ghostty.service",
-                 "#{xdg_data}/systemd/user/com.mitchellh.ghostty.service")
+    # clean up files older cask revisions installed under wrong names/locations
+    FileUtils.rm("#{xdg_data}/applications/ghostty.desktop", force: true)
+    FileUtils.rm("#{xdg_data}/icons/ghostty.png", force: true)
+    FileUtils.rm("#{xdg_data}/systemd/user/com.mitchellh.ghostty.service", force: true)
   end
 
   uninstall_postflight do
     xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
     FileUtils.rm("#{xdg_data}/applications/com.mitchellh.ghostty.desktop", force: true)
     FileUtils.rm(Dir["#{xdg_data}/icons/hicolor/*/apps/com.mitchellh.ghostty.png"], force: true)
-    FileUtils.rm("#{xdg_data}/systemd/user/com.mitchellh.ghostty.service", force: true)
+    system "gtk-update-icon-cache", "-f", "-t", "#{xdg_data}/icons/hicolor"
     # leftovers from cask revisions that installed under the wrong names
     FileUtils.rm("#{xdg_data}/applications/ghostty.desktop", force: true)
     FileUtils.rm("#{xdg_data}/icons/ghostty.png", force: true)
+    FileUtils.rm("#{xdg_data}/systemd/user/com.mitchellh.ghostty.service", force: true)
   end
 
   zap trash: "~/.config/ghostty"


### PR DESCRIPTION
Fixes Ghostty silently failing to launch from the GNOME launcher, as reported by a user. Follow-up to #544, which fixed the icons but not this.

The desktop file sets `DBusActivatable=true`, so GNOME launches by D-Bus activation instead of the `Exec=` line, with no fallback on failure. The bundled service file execs the AppImage build server's path (`/__w/ghostty-appimage/...`), which exists on no one's machine, and the cask was copying it to `systemd/user/` rather than a D-Bus services directory anyway. Cold launches from the GUI died silently; it only worked if ghostty was already running, since the bus name then existed. The reporting user confirmed flipping the flag fixes launch.

The cask now sets `DBusActivatable=false` so GNOME uses the rewritten `Exec=`, stops copying the service file, runs `gtk-update-icon-cache` after installing or removing icons so they appear without a session restart, and cleans up the stale files earlier revisions installed, so existing users get fixed on upgrade rather than only on reinstall.

Verified: simulated the full postflight and uninstall against the extracted 1.3.1 AppImage in a scratch `XDG_DATA_HOME`: the desktop file keeps its app-id name with `DBusActivatable=false` and `--gtk-single-instance=true` intact, ten icon sizes install, the icon cache builds, and no stale files remain.

Related: #544