### PR TITLE
Add T3 Code Linux cask

### DIFF
--- a/Casks/t3-code-linux.rb
+++ b/Casks/t3-code-linux.rb
@@ -1,0 +1,49 @@
+cask "t3-code-linux" do
+  os linux: "linux"
+
+  version "0.0.36"
+  sha256 x86_64_linux: "f19c36ce903331f8d5906f2f90e6fbaae576fde53ab37e1eeb201f3c50c9acf1"
+
+  url "https://github.com/pingdotgg/t3code/releases/download/v#{version}/T3-Code-#{version}-x86_64.AppImage"
+  name "T3 Code"
+  desc "Desktop control surface for local coding agents"
+  homepage "https://github.com/pingdotgg/t3code"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on arch: :x86_64
+  depends_on linux: :any
+  depends_on formula: "squashfs"
+
+  binary "t3code.wrapper.sh", target: "t3code"
+  artifact "squashfs-root/usr/share/icons/hicolor/512x512/apps/t3code.png",
+           target: "#{Dir.home}/.local/share/icons/t3code.png"
+  artifact "squashfs-root/t3code.desktop",
+           target: "#{Dir.home}/.local/share/applications/t3code.desktop"
+
+  preflight do
+    appimage_path = "#{staged_path}/T3-Code-#{version}-x86_64.AppImage"
+    system "chmod", "+x", appimage_path
+    system appimage_path, "--appimage-extract", chdir: staged_path
+    FileUtils.rm appimage_path
+
+    File.write("#{staged_path}/t3code.wrapper.sh", <<~EOS)
+      #!/bin/sh
+      export T3CODE_DISABLE_AUTO_UPDATE=1
+      exec "#{staged_path}/squashfs-root/AppRun" "$@"
+    EOS
+    FileUtils.chmod 0755, "#{staged_path}/t3code.wrapper.sh"
+
+    FileUtils.mkdir_p "#{Dir.home}/.local/share/applications"
+    FileUtils.mkdir_p "#{Dir.home}/.local/share/icons"
+
+    desktop_path = "#{staged_path}/squashfs-root/t3code.desktop"
+    desktop_content = File.read(desktop_path)
+    # AppRun adds --no-sandbox itself when unprivileged user namespaces are unavailable.
+    desktop_content.gsub!(/^Exec=.*/, "Exec=#{HOMEBREW_PREFIX}/bin/t3code %U")
+    File.write(desktop_path, desktop_content)
+  end
+end


### PR DESCRIPTION
# Add T3 Code Linux cask

## Summary

- add an x86_64 Linux cask for T3 Code `0.0.36`
- extract the official AppImage during installation so T3 Code works without AppImage runtime/FUSE support
- install a `t3code` launcher, desktop entry, and application icon
- disable T3 Code's AppImage self-updater so Homebrew remains responsible for upgrades
- use the bundled `AppRun` sandbox capability check instead of the desktop entry's unconditional `--no-sandbox`

This is being proposed to the experimental tap first, as requested by the production tap README for new or unfinished casks.

The extraction approach is similar to existing AppImage casks in this repository, including:

- https://github.com/ublue-os/homebrew-experimental-tap/blob/main/Casks/craft-agents-linux.rb
- https://github.com/ublue-os/homebrew-experimental-tap/blob/main/Casks/emdash-linux.rb

## Upstream status

Guidance on update ownership and sandbox policy was requested in [pingdotgg/t3code#8288](https://github.com/pingdotgg/t3code/discussions/8288). No response has been received as of August 31, 2026.

That response remains welcome, but is no longer considered a blocker for merging into the experimental tap. The current implementation is supported by source inspection and Dakota VM testing, and experimental inclusion will make broader validation easier. It can still be adjusted later if upstream provides different guidance.

## Sandbox behavior

The AppImage's bundled desktop entry currently uses:

```text
Exec=AppRun --no-sandbox %U
```

This cask rewrites it to the Homebrew-managed launcher without the unconditional flag:

```text
Exec=<Homebrew prefix>/bin/t3code %U
```

This is intentional, but remains open for discussion:

- The bundled `AppRun` probes `unshare -Ur true` and adds `--no-sandbox` itself when unprivileged user namespaces are unavailable.
- Testing in a Dakota/Bluefin GNOME OS VM confirmed the intended conditional path with T3 Code `0.0.33`. The global `--no-sandbox` flag was absent, and a Chromium child ran in separate user and PID namespaces with `NoNewPrivs: 1` and `Seccomp: 2`.
- The extracted `chrome-sandbox` is user-owned and mode `0755`; a user-owned Homebrew cask cannot safely reproduce a root-owned setuid sandbox.
- Keeping the upstream desktop entry's unconditional flag may maximize compatibility on unusual hosts, but disables Chromium's sandbox even where the user-namespace path works.

The current cask prefers the conditional behavior already implemented by `AppRun`.

## Update behavior

The launcher exports T3 Code's supported `T3CODE_DISABLE_AUTO_UPDATE=1` setting. The Linux self-updater downloads another AppImage, which would bypass Homebrew's version and checksum management and may not be executable on the systems this cask targets. Updates should instead come through Homebrew.

The cask's `livecheck` and platform-specific checksum metadata enroll it in this repository's daily `brew bump` workflow. I verified the same path locally with `brew bump-cask-pr --write-only`, which detected `0.0.36`, downloaded the official AppImage, and updated the version and SHA-256 correctly.

One repository-policy detail is worth confirming: the experimental tap currently squash-merges successful bot-generated cask bump PRs automatically. This PR does not change that policy, but T3 Code's extracted layout and launcher behavior still benefit from human/GUI validation when upstream packaging changes.

## Testing

- `brew bump-cask-pr --write-only --version=0.0.36`
- `brew livecheck` (`0.0.36 ==> 0.0.36`)
- `brew style Casks/t3-code-linux.rb`
- `brew audit --cask --online t3-code-linux`
- `brew readall --aliases ublue-os/experimental-tap`
- verified the downloaded AppImage SHA-256 matches the digest published with the `v0.0.36` GitHub release
- verified one-time AppImage extraction produces the declared `AppRun`, desktop entry, and icon artifacts
- confirmed the `v0.0.36` desktop entry still contains the unconditional `--no-sandbox` flag and its bundled `AppRun` still implements the conditional user-namespace probe
- installed cask version `0.0.33` in a Dakota/Bluefin GNOME OS VM using a disposable local tap
- launched from the installed desktop entry and completed three consecutive full termination/relaunch cycles successfully
- confirmed the sandboxed Chromium child uses separate user and PID namespaces, `NoNewPrivs: 1`, and `Seccomp: 2`
- on the first `0.0.33` launch, the UI reported a `fetch-session-state` HTTP 500. The built-in **Reload App** action recovered it, and three subsequent clean launches succeeded directly (3/3). The symptom is consistent with [pingdotgg/t3code#3513](https://github.com/pingdotgg/t3code/issues/3513), but this small sample does not prove the cask path played no role.

## Remaining validation

- repeat the clean Dakota VM GUI test with `0.0.36` and the explicit updater opt-out before considering promotion to the production tap

T3 Code currently publishes the Linux AppImage for x86_64 only, which is enforced by the cask's platform dependencies.
