### PR TITLE
fix: migrate casks off deprecated Homebrew hooks

### DIFF
--- a/.github/workflows/bump-ci.yml
+++ b/.github/workflows/bump-ci.yml
@@ -148,11 +148,10 @@ jobs:
             echo "::endgroup::"
           done
 
-      # The `promote` job below is what actually runs pr-pull; this label is kept as
-      # a visible marker of what passed. Guard it anyway, since a human seeing the
-      # label may hand-trigger publish.yml, which pushes to main.
-      - name: Label PR on Success
-        if: success()
+      # Only formula changes use pr-pull. Cask-only bumps go directly to the
+      # squash-merge job and must not receive the bottle-publishing label.
+      - name: Label formula PR on success
+        if: success() && steps.changed.outputs.formulae != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/Casks/chatgpt-linux.rb
+++ b/Casks/chatgpt-linux.rb
@@ -26,20 +26,20 @@ cask "chatgpt-linux" do
   artifact "usr/share/applications/chatgpt.desktop",
            target: "#{Dir.home}/.local/share/applications/chatgpt.desktop"
   artifact "usr/share/pixmaps/chatgpt.png",
-           target: "#{Dir.home}/.local/share/pixmaps/chatgpt.png"
+           target: "#{Dir.home}/.local/share/icons/chatgpt.png"
 
-  preflight do
-    rpm2cpio = Formula["rpm2cpio"].bin/"rpm2cpio"
-    cpio = Formula["cpio"].bin/"cpio"
-    rpm_path = staged_path/"chatgpt-#{version}-1.#{arch}.rpm"
-    system "sh", "-c", "'#{rpm2cpio}' '#{rpm_path}' | '#{cpio}' -idm --quiet", chdir: staged_path
-    FileUtils.rm rpm_path
+  preflight_steps do
+    # Normalise the arch- and version-specific RPM filename, then split extraction.
+    move "chatgpt-{{version}}-1.*.rpm", "chatgpt.rpm", source_glob: true
+    run "{{HOMEBREW_PREFIX}}/bin/rpm2cpio", args:        ["{{staged_path}}/chatgpt.rpm"],
+                                            stdout_path: "chatgpt.cpio"
+    run "{{HOMEBREW_PREFIX}}/bin/cpio", args: ["-idm", "--quiet"], stdin_path: "chatgpt.cpio",
+        chdir: "{{staged_path}}"
+    remove ["chatgpt.rpm", "chatgpt.cpio"]
 
-    desktop_file = staged_path/"usr/share/applications/chatgpt.desktop"
-    content = File.read(desktop_file)
-    content.gsub!(/^Exec=.*/, "Exec=#{HOMEBREW_PREFIX}/bin/chatgpt %U")
-    content.gsub!(/^Icon=.*/, "Icon=#{Dir.home}/.local/share/pixmaps/chatgpt.png")
-    File.write(desktop_file, content)
+    inreplace "usr/share/applications/chatgpt.desktop", /^Exec=.*/,
+              "Exec={{HOMEBREW_PREFIX}}/bin/chatgpt %U", audit_result: false
+    inreplace "usr/share/applications/chatgpt.desktop", /^Icon=.*/, "Icon=chatgpt", audit_result: false
   end
 
   zap trash: [

--- a/Casks/claude-desktop-linux.rb
+++ b/Casks/claude-desktop-linux.rb
@@ -28,15 +28,14 @@ cask "claude-desktop-linux" do
   artifact "usr/share/applications/com.anthropic.Claude.desktop",
            target: "#{Dir.home}/.local/share/applications/com.anthropic.Claude.desktop"
 
-  preflight do
-    system "#{formula_opt_bin("dpkg")}/dpkg-deb", "-x",
-           "#{staged_path}/claude-desktop_#{version}_amd64.deb", staged_path
+  preflight_steps do
+    run "{{HOMEBREW_PREFIX}}/opt/dpkg/bin/dpkg-deb",
+        args: ["-x", "{{staged_path}}/claude-desktop_{{version}}_amd64.deb", "{{staged_path}}"]
 
-    desktop_file = "#{staged_path}/usr/share/applications/com.anthropic.Claude.desktop"
-    content = File.read(desktop_file)
-    content.gsub!(/^Exec=.*/, "Exec=#{HOMEBREW_PREFIX}/bin/claude-desktop %U")
-    content.gsub!(/^Icon=.*/, "Icon=#{Dir.home}/.local/share/icons/hicolor/256x256/apps/claude-desktop.png")
-    File.write(desktop_file, content)
+    inreplace "usr/share/applications/com.anthropic.Claude.desktop", /^Exec=.*/,
+              "Exec={{HOMEBREW_PREFIX}}/bin/claude-desktop %U", audit_result: false
+    inreplace "usr/share/applications/com.anthropic.Claude.desktop", /^Icon=.*/,
+              "Icon=claude-desktop", audit_result: false
   end
 
   zap trash: [

--- a/Casks/clion-linux.rb
+++ b/Casks/clion-linux.rb
@@ -28,22 +28,25 @@ cask "clion-linux" do
   conflicts_with cask: "jetbrains-toolbox-linux"
   depends_on linux: :any
 
-  binary "#{HOMEBREW_PREFIX}/Caskroom/clion-linux/#{version}/clion-#{version.csv.first}/bin/clion"
+  binary "clion/bin/clion"
   artifact "jetbrains-clion.desktop",
            target: "#{Dir.home}/.local/share/applications/jetbrains-clion.desktop"
-  artifact "clion-#{version.csv.first}/bin/clion.svg",
+  artifact "clion/bin/clion.svg",
            target: "#{Dir.home}/.local/share/icons/hicolor/scalable/apps/clion.svg"
 
-  preflight do
-    File.write("#{staged_path}/clion-#{version.csv.first}/bin/clion64.vmoptions", "-Dide.no.platform.update=true\n", mode: "a+")
-    FileUtils.mkdir_p("#{Dir.home}/.local/share/applications")
-    FileUtils.mkdir_p("#{Dir.home}/.local/share/icons/hicolor/scalable/apps")
-    File.write("#{staged_path}/jetbrains-clion.desktop", <<~EOS)
+  preflight_steps do
+    # Normalise the versioned directory before referring to it in declarative steps.
+    move "clion-*", "clion", source_glob: true
+    touch "clion/bin/clion64.vmoptions"
+    inreplace "clion/bin/clion64.vmoptions", /\z/, "-Dide.no.platform.update=true\n"
+    mkdir_p ".local/share/applications", base: :home
+    mkdir_p ".local/share/icons/hicolor/scalable/apps", base: :home
+    write_file "jetbrains-clion.desktop", <<~EOS
       [Desktop Entry]
       Version=1.0
       Name=CLion
       Comment=A cross-platform C and C++ IDE
-      Exec=#{HOMEBREW_PREFIX}/bin/clion %u
+      Exec={{HOMEBREW_PREFIX}}/bin/clion %u
       Icon=clion
       Type=Application
       Categories=Development;IDE;
@@ -54,8 +57,12 @@ cask "clion-linux" do
     EOS
   end
 
-  postflight do
-    system "/usr/bin/xdg-icon-resource", "forceupdate"
+  postflight_steps do
+    mkdir_p "xdg-user-data"
+    symlink ".local/share", "xdg-user-data/share", source_base: :home
+    run "/usr/bin/xdg-icon-resource", args: ["forceupdate"], must_succeed: false,
+                                  env: { "XDG_DATA_HOME" => "{{staged_path}}/xdg-user-data/share" },
+                                  writable_paths: [".local/share/icons/hicolor"], writable_base: :home
   end
 
   zap trash: [

--- a/Casks/craft-agents-linux.rb
+++ b/Casks/craft-agents-linux.rb
@@ -16,33 +16,31 @@ cask "craft-agents-linux" do
 
   binary "squashfs-root/@craft-agentelectron", target: "craft-agents"
 
-  preflight do
-    appimage_path = "#{staged_path}/Craft-Agents-#{version}-linux-x64.AppImage"
-    system "chmod", "+x", appimage_path
-    system appimage_path, "--appimage-extract", chdir: staged_path
-    FileUtils.rm(appimage_path)
+  preflight_steps do
+    # Normalise the versioned AppImage filename before extraction.
+    move "Craft-Agents-{{version}}-linux-x64.AppImage", "craft-agents.AppImage", source_glob: true
+    set_permissions "craft-agents.AppImage", "+x"
+    run "craft-agents.AppImage", args: ["--appimage-extract"], base: :staged_path, chdir: "{{staged_path}}"
+    remove "craft-agents.AppImage"
   end
 
-  postflight do
-    icons_dir = "#{Dir.home}/.local/share/icons/hicolor/512x512/apps"
-    apps_dir = "#{Dir.home}/.local/share/applications"
-    FileUtils.mkdir_p(icons_dir)
-    FileUtils.cp("#{staged_path}/squashfs-root/usr/share/icons/hicolor/512x512/apps/@craft-agentelectron.png",
-                 icons_dir)
-    FileUtils.cp("#{staged_path}/squashfs-root/@craft-agentelectron.desktop", apps_dir)
-    desktop_path = "#{apps_dir}/@craft-agentelectron.desktop"
-    if File.exist?(desktop_path)
-      content = File.read(desktop_path)
-      content.gsub!(/^Exec=AppRun/, "Exec=#{HOMEBREW_PREFIX}/bin/craft-agents")
-      content.gsub!(/^Icon=.*/, "Icon=#{icons_dir}/@craft-agentelectron.png")
-      content.gsub!(/^StartupWMClass=.*/, "StartupWMClass=@craft-agent/electron")
-      File.write(desktop_path, content)
-    end
+  postflight_steps do
+    mkdir_p ".local/share/icons/hicolor/512x512/apps", base: :home
+    copy "squashfs-root/usr/share/icons/hicolor/512x512/apps/@craft-agentelectron.png",
+         ".local/share/icons/hicolor/512x512/apps/@craft-agentelectron.png", target_base: :home
+    copy "squashfs-root/@craft-agentelectron.desktop", ".local/share/applications/@craft-agentelectron.desktop",
+         target_base: :home
+    inreplace ".local/share/applications/@craft-agentelectron.desktop", /^Exec=AppRun/,
+              "Exec={{HOMEBREW_PREFIX}}/bin/craft-agents", base: :home, audit_result: false
+    inreplace ".local/share/applications/@craft-agentelectron.desktop", /^Icon=.*/,
+              "Icon=@craft-agentelectron", base: :home, audit_result: false
+    inreplace ".local/share/applications/@craft-agentelectron.desktop", /^StartupWMClass=.*/,
+              "StartupWMClass=@craft-agent/electron", base: :home, audit_result: false
   end
 
-  uninstall_postflight do
-    FileUtils.rm("#{Dir.home}/.local/share/icons/hicolor/512x512/apps/@craft-agentelectron.png")
-    FileUtils.rm("#{Dir.home}/.local/share/applications/@craft-agentelectron.desktop")
+  uninstall_postflight_steps do
+    remove ".local/share/icons/hicolor/512x512/apps/@craft-agentelectron.png", base: :home
+    remove ".local/share/applications/@craft-agentelectron.desktop", base: :home
   end
 
   zap trash: [

--- a/Casks/cursor-linux.rb
+++ b/Casks/cursor-linux.rb
@@ -6,8 +6,7 @@ cask "cursor-linux" do
   sha256 arm64_linux:  "8e30411a75933139ed7adadeaefd8fe36d4a7a246b182eb679e1e6e1cc3b7851",
          x86_64_linux: "a02023f3b69f69d5e3f0ba02fe778c26237b8ac9760b59af6513b6e91f0478b2"
 
-  url "https://downloads.cursor.com/production/#{version.csv.second}/linux/#{arch}/Cursor-#{version.csv.first}-#{file_arch}.AppImage",
-      verified: "downloads.cursor.com/"
+  url "https://downloads.cursor.com/production/#{version.csv.second}/linux/#{arch}/Cursor-#{version.csv.first}-#{file_arch}.AppImage"
   name "Cursor"
   desc "Write, edit, and chat about your code with AI"
   homepage "https://www.cursor.com/"
@@ -25,7 +24,7 @@ cask "cursor-linux" do
 
   depends_on linux: :any
 
-  binary "Cursor-#{version.csv.first}-#{file_arch}.AppImage", target: "cursor"
+  binary "Cursor.AppImage", target: "cursor"
   bash_completion "#{staged_path}/squashfs-root/usr/share/cursor/resources/completions/bash/cursor"
   zsh_completion  "#{staged_path}/squashfs-root/usr/share/cursor/resources/completions/zsh/_cursor"
   artifact "cursor.desktop",
@@ -33,29 +32,26 @@ cask "cursor-linux" do
   artifact "cursor.png",
            target: "#{Dir.home}/.local/share/icons/hicolor/512x512/apps/cursor.png"
 
-  preflight do
-    FileUtils.mkdir_p "#{Dir.home}/.local/share/applications"
-    FileUtils.mkdir_p "#{Dir.home}/.local/share/icons/hicolor/512x512/apps"
+  preflight_steps do
+    mkdir_p ".local/share/applications", base: :home
+    mkdir_p ".local/share/icons/hicolor/512x512/apps", base: :home
 
-    appimage_name = "Cursor-#{version.csv.first}-#{file_arch}.AppImage"
+    # Normalise the architecture- and version-specific filename before extraction.
+    move "Cursor-*.AppImage", "Cursor.AppImage", source_glob: true
+    set_permissions "Cursor.AppImage", "+x"
+    run "Cursor.AppImage", args: ["--appimage-extract"], base: :staged_path, chdir: "{{staged_path}}"
 
-    # Make AppImage executable
-    FileUtils.chmod "+x", "#{staged_path}/#{appimage_name}"
+    if_path_exists "squashfs-root/usr/share/icons/hicolor/512x512/apps/cursor.png" do
+      copy "squashfs-root/usr/share/icons/hicolor/512x512/apps/cursor.png", "cursor.png"
+    end
 
-    # Extract AppImage contents to get resources (icon, completions, etc.)
-    system "#{staged_path}/#{appimage_name}", "--appimage-extract", chdir: staged_path
-
-    # Copy icon from extracted AppImage
-    icon_source = "#{staged_path}/squashfs-root/usr/share/icons/hicolor/512x512/apps/cursor.png"
-    FileUtils.cp icon_source, "#{staged_path}/cursor.png" if File.exist?(icon_source)
-
-    File.write("#{staged_path}/cursor.desktop", <<~EOS)
+    write_file "cursor.desktop", <<~EOS
       [Desktop Entry]
       Name=Cursor
       Comment=AI-first coding environment
       GenericName=Text Editor
-      Exec=#{HOMEBREW_PREFIX}/bin/cursor %F
-      Icon=#{Dir.home}/.local/share/icons/hicolor/512x512/apps/cursor.png
+      Exec={{HOMEBREW_PREFIX}}/bin/cursor %F
+      Icon=cursor
       Type=Application
       StartupNotify=false
       StartupWMClass=Cursor
@@ -66,12 +62,14 @@ cask "cursor-linux" do
 
       [Desktop Action new-empty-window]
       Name=New Empty Window
-      Exec=#{HOMEBREW_PREFIX}/bin/cursor --new-window %F
-      Icon=#{Dir.home}/.local/share/icons/hicolor/512x512/apps/cursor.png
+      Exec={{HOMEBREW_PREFIX}}/bin/cursor --new-window %F
+      Icon=cursor
     EOS
 
-    # Create a placeholder icon if extraction fails
-    FileUtils.touch "#{staged_path}/cursor.png" unless File.exist?("#{staged_path}/cursor.png")
+    # Keep a placeholder when the extracted image has no icon.
+    unless_path_exists "cursor.png" do
+      touch "cursor.png"
+    end
   end
 
   zap trash: [

--- a/Casks/datagrip-linux.rb
+++ b/Casks/datagrip-linux.rb
@@ -28,22 +28,25 @@ cask "datagrip-linux" do
   conflicts_with cask: "jetbrains-toolbox-linux"
   depends_on linux: :any
 
-  binary "#{HOMEBREW_PREFIX}/Caskroom/datagrip-linux/#{version}/DataGrip-#{version.csv.first}/bin/datagrip"
+  binary "datagrip/bin/datagrip"
   artifact "jetbrains-datagrip.desktop",
            target: "#{Dir.home}/.local/share/applications/jetbrains-datagrip.desktop"
-  artifact "DataGrip-#{version.csv.first}/bin/datagrip.svg",
+  artifact "datagrip/bin/datagrip.svg",
            target: "#{Dir.home}/.local/share/icons/hicolor/scalable/apps/datagrip.svg"
 
-  preflight do
-    File.write("#{staged_path}/DataGrip-#{version.csv.first}/bin/datagrip64.vmoptions", "-Dide.no.platform.update=true\n", mode: "a+")
-    FileUtils.mkdir_p("#{Dir.home}/.local/share/applications")
-    FileUtils.mkdir_p("#{Dir.home}/.local/share/icons/hicolor/scalable/apps")
-    File.write("#{staged_path}/jetbrains-datagrip.desktop", <<~EOS)
+  preflight_steps do
+    # Normalise the versioned directory before referring to it in declarative steps.
+    move "DataGrip-*", "datagrip", source_glob: true
+    touch "datagrip/bin/datagrip64.vmoptions"
+    inreplace "datagrip/bin/datagrip64.vmoptions", /\z/, "-Dide.no.platform.update=true\n"
+    mkdir_p ".local/share/applications", base: :home
+    mkdir_p ".local/share/icons/hicolor/scalable/apps", base: :home
+    write_file "jetbrains-datagrip.desktop", <<~EOS
       [Desktop Entry]
       Version=1.0
       Name=DataGrip
       Comment=The IDE for databases and SQL
-      Exec=#{HOMEBREW_PREFIX}/bin/datagrip %u
+      Exec={{HOMEBREW_PREFIX}}/bin/datagrip %u
       Icon=datagrip
       Type=Application
       Categories=Development;IDE;
@@ -54,8 +57,12 @@ cask "datagrip-linux" do
     EOS
   end
 
-  postflight do
-    system "/usr/bin/xdg-icon-resource", "forceupdate"
+  postflight_steps do
+    mkdir_p "xdg-user-data"
+    symlink ".local/share", "xdg-user-data/share", source_base: :home
+    run "/usr/bin/xdg-icon-resource", args: ["forceupdate"], must_succeed: false,
+                                  env: { "XDG_DATA_HOME" => "{{staged_path}}/xdg-user-data/share" },
+                                  writable_paths: [".local/share/icons/hicolor"], writable_base: :home
   end
 
   zap trash: [

--- a/Casks/dataspell-linux.rb
+++ b/Casks/dataspell-linux.rb
@@ -28,22 +28,25 @@ cask "dataspell-linux" do
   conflicts_with cask: "jetbrains-toolbox-linux"
   depends_on linux: :any
 
-  binary "#{HOMEBREW_PREFIX}/Caskroom/dataspell-linux/#{version}/dataspell-#{version.csv.first}/bin/dataspell"
+  binary "dataspell/bin/dataspell"
   artifact "jetbrains-dataspell.desktop",
            target: "#{Dir.home}/.local/share/applications/jetbrains-dataspell.desktop"
-  artifact "dataspell-#{version.csv.first}/bin/dataspell.svg",
+  artifact "dataspell/bin/dataspell.svg",
            target: "#{Dir.home}/.local/share/icons/hicolor/scalable/apps/dataspell.svg"
 
-  preflight do
-    File.write("#{staged_path}/dataspell-#{version.csv.first}/bin/dataspell64.vmoptions", "-Dide.no.platform.update=true\n", mode: "a+")
-    FileUtils.mkdir_p("#{Dir.home}/.local/share/applications")
-    FileUtils.mkdir_p("#{Dir.home}/.local/share/icons/hicolor/scalable/apps")
-    File.write("#{staged_path}/jetbrains-dataspell.desktop", <<~EOS)
+  preflight_steps do
+    # Normalise the versioned directory before referring to it in declarative steps.
+    move "dataspell-*", "dataspell", source_glob: true
+    touch "dataspell/bin/dataspell64.vmoptions"
+    inreplace "dataspell/bin/dataspell64.vmoptions", /\z/, "-Dide.no.platform.update=true\n"
+    mkdir_p ".local/share/applications", base: :home
+    mkdir_p ".local/share/icons/hicolor/scalable/apps", base: :home
+    write_file "jetbrains-dataspell.desktop", <<~EOS
       [Desktop Entry]
       Version=1.0
       Name=DataSpell
       Comment=The IDE for data analysis
-      Exec=#{HOMEBREW_PREFIX}/bin/dataspell %u
+      Exec={{HOMEBREW_PREFIX}}/bin/dataspell %u
       Icon=dataspell
       Type=Application
       Categories=Development;IDE;
@@ -54,8 +57,12 @@ cask "dataspell-linux" do
     EOS
   end
 
-  postflight do
-    system "/usr/bin/xdg-icon-resource", "forceupdate"
+  postflight_steps do
+    mkdir_p "xdg-user-data"
+    symlink ".local/share", "xdg-user-data/share", source_base: :home
+    run "/usr/bin/xdg-icon-resource", args: ["forceupdate"], must_succeed: false,
+                                  env: { "XDG_DATA_HOME" => "{{staged_path}}/xdg-user-data/share" },
+                                  writable_paths: [".local/share/icons/hicolor"], writable_base: :home
   end
 
   zap trash: [

--- a/Casks/devpod-linux.rb
+++ b/Casks/devpod-linux.rb
@@ -2,8 +2,7 @@ cask "devpod-linux" do
   version "0.6.15"
   sha256 "eb8bfefc4f2c3f20bce370877e985fcc750858f7f06a5db06cfe339cd1eca9ba"
 
-  url "https://github.com/loft-sh/devpod/releases/download/v#{version}/DevPod_linux_amd64.AppImage",
-      verified: "github.com/loft-sh/devpod/"
+  url "https://github.com/loft-sh/devpod/releases/download/v#{version}/DevPod_linux_amd64.AppImage"
   name "DevPod"
   desc "Reproducible developer environments using dev containers"
   homepage "https://devpod.sh/"
@@ -17,29 +16,30 @@ cask "devpod-linux" do
 
   binary "squashfs-root/AppRun", target: "devpod"
 
-  preflight do
-    appimage_path = "#{staged_path}/DevPod_linux_amd64.AppImage"
-    system "chmod", "+x", appimage_path
-    system appimage_path, "--appimage-extract", chdir: staged_path
-    FileUtils.rm appimage_path
+  preflight_steps do
+    # Normalise the AppImage filename before extraction.
+    move "DevPod_linux_amd64.AppImage", "devpod.AppImage"
+    set_permissions "devpod.AppImage", "+x"
+    run "devpod.AppImage", args: ["--appimage-extract"], base: :staged_path, chdir: "{{staged_path}}"
+    remove "devpod.AppImage"
   end
 
-  postflight do
-    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
-    FileUtils.mkdir_p "#{xdg_data}/applications"
-    FileUtils.mkdir_p "#{xdg_data}/icons/hicolor/512x512/apps"
+  postflight_steps do
+    mkdir_p ".local/share/applications", base: :home
+    mkdir_p ".local/share/icons/hicolor/512x512/apps", base: :home
 
-    icon_source = "#{staged_path}/squashfs-root/devpod.png"
-    icon_target = "#{xdg_data}/icons/hicolor/512x512/apps/devpod.png"
-    FileUtils.cp(icon_source, icon_target) if File.exist?(icon_source)
+    if_path_exists "squashfs-root/devpod.png" do
+      copy "squashfs-root/devpod.png", ".local/share/icons/hicolor/512x512/apps/devpod.png",
+           target_base: :home
+    end
 
-    File.write("#{xdg_data}/applications/devpod.desktop", <<~EOS)
+    write_file ".local/share/applications/devpod.desktop", <<~EOS, base: :home
       [Desktop Entry]
       Name=DevPod
       Comment=Reproducible developer environments using dev containers
       GenericName=Dev Container Tool
-      Exec=#{HOMEBREW_PREFIX}/bin/devpod
-      Icon=#{icon_target}
+      Exec={{HOMEBREW_PREFIX}}/bin/devpod
+      Icon=devpod
       Type=Application
       StartupNotify=true
       StartupWMClass=DevPod
@@ -48,10 +48,9 @@ cask "devpod-linux" do
     EOS
   end
 
-  uninstall_postflight do
-    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
-    FileUtils.rm("#{xdg_data}/applications/devpod.desktop", force: true)
-    FileUtils.rm("#{xdg_data}/icons/hicolor/512x512/apps/devpod.png", force: true)
+  uninstall_postflight_steps do
+    remove ".local/share/applications/devpod.desktop", base: :home
+    remove ".local/share/icons/hicolor/512x512/apps/devpod.png", base: :home
   end
 
   zap trash: [

--- a/Casks/dockerd-linux.rb
+++ b/Casks/dockerd-linux.rb
@@ -28,37 +28,27 @@ cask "dockerd-linux" do
   binary "docker-rootless-extras/dockerd-rootless.sh", target: "dockerd-rootless"
   binary "docker-rootless-extras/rootlesskit"
 
-  preflight do
-    extras_url = "https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-#{version}.tgz"
-
-    ohai "Downloading docker-rootless-extras..."
-    system_command "curl", args: ["-L", extras_url, "-o", "#{staged_path}/extras.tgz"]
-
-    ohai "Extracting extras..."
-    system_command "tar", args: ["-xzf", "#{staged_path}/extras.tgz", "-C", staged_path]
-
-    File.delete("#{staged_path}/extras.tgz")
+  preflight_steps do
+    run "curl",
+        args: ["-L", "https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-{{version}}.tgz",
+               "-o", "extras.tgz"],
+        chdir: "{{staged_path}}", network_access: true
+    run "tar", args: ["-xzf", "extras.tgz"], chdir: "{{staged_path}}"
+    remove "extras.tgz"
   end
 
-  postflight do
-    require "fileutils"
+  postflight_steps do
+    mkdir_p ".config/systemd/user", base: :home
 
-    systemd_dir = File.expand_path("~/.config/systemd/user")
-    service_file = File.join(systemd_dir, "dockerd-rootless.service")
-
-    ohai "Creating systemd user service..."
-    FileUtils.mkdir_p(systemd_dir)
-
-    # Normal brew service don't want to work with Casks
-    service_content = <<~SERVICE
+    write_file ".config/systemd/user/dockerd-rootless.service", <<~SERVICE, base: :home
       [Unit]
       Description=Docker Application Container Engine (Rootless)
       Documentation=https://docs.docker.com/go/rootless/
 
       [Service]
-      Environment=PATH=#{HOMEBREW_PREFIX}/bin:#{HOMEBREW_PREFIX}/sbin:/usr/bin:/usr/sbin:/bin
+      Environment=PATH={{HOMEBREW_PREFIX}}/bin:{{HOMEBREW_PREFIX}}/sbin:/usr/bin:/usr/sbin:/bin
       Environment=XDG_RUNTIME_DIR=/run/user/%U
-      ExecStart=#{HOMEBREW_PREFIX}/bin/dockerd-rootless --iptables=false
+      ExecStart={{HOMEBREW_PREFIX}}/bin/dockerd-rootless --iptables=false
       ExecReload=/bin/kill -s HUP $MAINPID
       TimeoutSec=0
       RestartSec=2
@@ -80,21 +70,28 @@ cask "dockerd-linux" do
       [Install]
       WantedBy=default.target
     SERVICE
+    set_permissions ".config/systemd/user/dockerd-rootless.service", "0644", base: :home
 
-    File.write(service_file, service_content)
-    FileUtils.chmod(0644, service_file)
-
-    ohai "Systemd service created at #{service_file}"
-    ohai "Run 'systemctl --user daemon-reload' to load the service"
-    ohai "Then enable and start with: systemctl --user enable --now dockerd-rootless"
-
-    ohai "Configuring docker context..."
-    docker_cli = "#{HOMEBREW_PREFIX}/bin/docker"
-    docker_socket = "unix:///run/user/#{Process.uid}/docker.sock"
-    context_create_cmd = "#{docker_cli} context create rootless --docker host=#{docker_socket}"
-    system_command "sh",
-                   args: ["-c", "#{docker_cli} context inspect rootless >/dev/null 2>&1 || #{context_create_cmd}"]
-    system_command docker_cli, args: ["context", "use", "rootless"]
+    # Give the sandboxed Docker CLI a stable HOME whose .docker directory is a
+    # narrow handle onto the real user's config directory.
+    mkdir_p ".docker", base: :home
+    mkdir_p "docker-home"
+    symlink ".docker", "docker-home/.docker", source_base: :home
+    write_file "configure-docker-context.sh", <<~SH
+      #!/bin/sh
+      docker_cli="{{HOMEBREW_PREFIX}}/bin/docker"
+      docker_socket="unix:///run/user/$(id -u)/docker.sock"
+      "$docker_cli" context inspect rootless >/dev/null 2>&1 || \
+        "$docker_cli" context create rootless --docker host="$docker_socket"
+      "$docker_cli" context use rootless
+    SH
+    set_permissions "configure-docker-context.sh", "0755"
+    run "configure-docker-context.sh", base: :staged_path,
+                                       env: {
+                                         "DOCKER_CONFIG" => "{{staged_path}}/docker-home/.docker",
+                                         "HOME"          => "{{staged_path}}/docker-home",
+                                       },
+                                       writable_paths: [".docker"], writable_base: :home
   end
 
   # Does not seem work...

--- a/Casks/emacs-app-linux.rb
+++ b/Casks/emacs-app-linux.rb
@@ -1,17 +1,11 @@
 cask "emacs-app-linux" do
   arch arm: "arm64", intel: "amd64"
-  # Computed at cask-body scope: `on_arch_conditional` lives on Cask::DSL, not on
-  # the Cask::DSL::Base subclass the flight blocks below are instance_eval'd
-  # against, so calling it inside one would raise NoMethodError at install time.
-  # The blocks close over this local, which instance_eval does not disturb.
-  target_triplet = on_arch_conditional arm: "aarch64-unknown-linux-gnu", intel: "x86_64-pc-linux-gnu"
 
   version "30.2-18"
   sha256 arm64_linux:  "d2471179e3a7691148a585c04c573a9dc95ee26b448624f4a8131d73c2234698",
          x86_64_linux: "2d3d1c145fe8f0edf51f1275c5109eee116f98e2899498ca710ab96858fa0a70"
 
-  url "https://github.com/daegalus/linux-app-builds/releases/download/emacs-pgtk-#{version}/emacs-pgtk-#{version.split("-").first}-fedora-latest-#{arch}.tar.gz",
-      verified: "github.com/daegalus/linux-app-builds/"
+  url "https://github.com/daegalus/linux-app-builds/releases/download/emacs-pgtk-#{version}/emacs-pgtk-#{version.split("-").first}-fedora-latest-#{arch}.tar.gz"
   name "Emacs PGTK"
   desc "Text editor with PGTK support (Native Wayland and X11)"
   homepage "https://github.com/daegalus/linux-app-builds"
@@ -25,204 +19,209 @@ cask "emacs-app-linux" do
   depends_on formula: "libgccjit"
   depends_on formula: "tree-sitter@0.25"
 
-  # Binaries
-  binary "emacs-pgtk-#{version.split("-").first}-fedora-latest-#{arch}/run-emacs.sh", target: "emacs"
-  binary "emacs-pgtk-#{version.split("-").first}-fedora-latest-#{arch}/bin/emacs-#{version.split("-").first}", target: "emacs-#{version.split("-").first}"
-  binary "emacs-pgtk-#{version.split("-").first}-fedora-latest-#{arch}/bin/emacsclient"
-  binary "emacs-pgtk-#{version.split("-").first}-fedora-latest-#{arch}/bin/ctags"
-  binary "emacs-pgtk-#{version.split("-").first}-fedora-latest-#{arch}/bin/ebrowse"
-  binary "emacs-pgtk-#{version.split("-").first}-fedora-latest-#{arch}/bin/etags"
-  # Man pages
-  manpage "emacs-pgtk-#{version.split("-").first}-fedora-latest-#{arch}/share/man/man1/ctags.1.gz"
-  manpage "emacs-pgtk-#{version.split("-").first}-fedora-latest-#{arch}/share/man/man1/ebrowse.1.gz"
-  manpage "emacs-pgtk-#{version.split("-").first}-fedora-latest-#{arch}/share/man/man1/emacs.1.gz"
-  manpage "emacs-pgtk-#{version.split("-").first}-fedora-latest-#{arch}/share/man/man1/emacsclient.1.gz"
-  manpage "emacs-pgtk-#{version.split("-").first}-fedora-latest-#{arch}/share/man/man1/etags.1.gz"
-  # Libraries (needed for emacs to run)
-  artifact "emacs-pgtk-#{version.split("-").first}-fedora-latest-#{arch}/lib",
-           target: "#{HOMEBREW_PREFIX}/opt/emacs-app-linux/lib"
-  # Share directory (elisp, icons, schemas, man pages, etc.)
-  artifact "emacs-pgtk-#{version.split("-").first}-fedora-latest-#{arch}/share",
-           target: "#{HOMEBREW_PREFIX}/opt/emacs-app-linux/share"
-  # Libexec (helper binaries and compiled modules)
-  artifact "emacs-pgtk-#{version.split("-").first}-fedora-latest-#{arch}/libexec",
-           target: "#{HOMEBREW_PREFIX}/opt/emacs-app-linux/libexec"
+  binary "emacs/run-emacs.sh", target: "emacs"
+  binary "emacs/bin/emacs-#{version.split("-").first}", target: "emacs-#{version.split("-").first}"
+  binary "emacs/bin/emacsclient"
+  binary "emacs/bin/ctags"
+  binary "emacs/bin/ebrowse"
+  binary "emacs/bin/etags"
+  manpage "emacs/share/man/man1/ctags.1.gz"
+  manpage "emacs/share/man/man1/ebrowse.1.gz"
+  manpage "emacs/share/man/man1/emacs.1.gz"
+  manpage "emacs/share/man/man1/emacsclient.1.gz"
+  manpage "emacs/share/man/man1/etags.1.gz"
+  artifact "emacs/lib", target: "#{HOMEBREW_PREFIX}/opt/emacs-app-linux/lib"
+  artifact "emacs/share", target: "#{HOMEBREW_PREFIX}/opt/emacs-app-linux/share"
+  artifact "emacs/libexec", target: "#{HOMEBREW_PREFIX}/opt/emacs-app-linux/libexec"
 
-  preflight do
-    emacs_version = version.split("-").first
-    staged_prefix = "#{staged_path}/emacs-pgtk-#{emacs_version}-fedora-latest-#{arch}"
+  preflight_steps do
+    # Resolve the full upstream version and architecture from this payload, not
+    # the host CPU, so the same serialized steps work on both Linux architectures.
+    run "sh", args: ["-eu", "-c", <<~'SH']
+      export LC_ALL=C
+      emacs_version="{{version}}"
+      emacs_version=${emacs_version%%-*}
+      set -- "{{staged_path}}"/emacs-pgtk-"$emacs_version"-fedora-latest-*
+      [ "$#" -eq 1 ] && [ -d "$1" ]
+      payload=$1
+      case "$payload" in
+        *-arm64) target_triplet=aarch64-unknown-linux-gnu ;;
+        *-amd64) target_triplet=x86_64-pc-linux-gnu ;;
+        *) exit 1 ;;
+      esac
+      printf "emacs_version='%s'\ntarget_triplet='%s'\n" "$emacs_version" "$target_triplet" > "$payload/emacs-paths.sh"
 
-    # Make run-emacs.sh executable
-    FileUtils.chmod "+x", "#{staged_prefix}/run-emacs.sh"
+      # Emacs finds this relative dump link next to its versioned binary.
+      for dump in "$payload/libexec/emacs/$emacs_version/$target_triplet/"*.pdmp; do
+        [ -e "$dump" ] || break
+        ln -sf "../libexec/emacs/$emacs_version/$target_triplet/${dump##*/}" "$payload/bin/emacs-$emacs_version.pdmp"
+        break
+      done
 
-    # Create symlink to pdmp file in bin directory - Emacs automatically finds it there
-    # Emacs looks for {binary-name}.pdmp next to the binary (e.g., emacs-30.2.pdmp)
-    # Using a relative symlink saves ~12MB compared to copying
-    pdmp_source = Dir.glob("#{staged_prefix}/libexec/emacs/#{emacs_version}/#{target_triplet}/*.pdmp").first
-    if pdmp_source
-      relative_path = "../libexec/emacs/#{emacs_version}/#{target_triplet}/#{File.basename(pdmp_source)}"
-      FileUtils.ln_sf(relative_path, "#{staged_prefix}/bin/emacs-#{emacs_version}.pdmp")
-    end
-
-    # Update the run-emacs.sh script to include all necessary Homebrew library paths
-    script_path = "#{staged_prefix}/run-emacs.sh"
-    content = File.read(script_path)
-
-    # Add tree-sitter and libgccjit paths after the Homebrew lib path check
-    homebrew_paths = <<~PATHS
-      # Add Homebrew paths if they exist (for systems like immutable distros)
-      if [ -d "/home/linuxbrew/.linuxbrew/lib" ]; then
-        export LD_LIBRARY_PATH="/home/linuxbrew/.linuxbrew/lib:$LD_LIBRARY_PATH"
-      fi
-      # Add libgccjit (required for native compilation)
-      if [ -d "/home/linuxbrew/.linuxbrew/opt/libgccjit/lib/gcc/current" ]; then
-        export LD_LIBRARY_PATH="/home/linuxbrew/.linuxbrew/opt/libgccjit/lib/gcc/current:$LD_LIBRARY_PATH"
-      fi
-      # Add tree-sitter@0.25 (keg-only)
-      if [ -d "/home/linuxbrew/.linuxbrew/opt/tree-sitter@0.25/lib" ]; then
-        export LD_LIBRARY_PATH="/home/linuxbrew/.linuxbrew/opt/tree-sitter@0.25/lib:$LD_LIBRARY_PATH"
-      fi
-    PATHS
-
-    content.gsub!(
-      %r{# Add Homebrew paths.*?\n  export LD_LIBRARY_PATH="/home/linuxbrew/\.linuxbrew/lib:\$LD_LIBRARY_PATH"\nfi}m,
-      homebrew_paths.strip,
-    )
-
-    # Add Emacs data directory environment variables after the GSETTINGS_SCHEMA_DIR line
-    emacs_env_vars = <<~ENVVARS
-      export GSETTINGS_SCHEMA_DIR="$SCRIPT_DIR/share/glib-2.0/schemas"
-
-      # Set Emacs data directories (use Homebrew opt path when symlinked)
-      if [ -d "/home/linuxbrew/.linuxbrew/opt/emacs-app-linux/share/emacs/#{emacs_version}" ]; then
-        export EMACSDATA="/home/linuxbrew/.linuxbrew/opt/emacs-app-linux/share/emacs/#{emacs_version}/etc"
-        export EMACSPATH="/home/linuxbrew/.linuxbrew/opt/emacs-app-linux/libexec/emacs/#{emacs_version}/#{target_triplet}"
-        export EMACSDOC="/home/linuxbrew/.linuxbrew/opt/emacs-app-linux/share/emacs/#{emacs_version}/etc"
-        # Set EMACSLOADPATH with trailing colon to make Emacs use this path and automatically append subdirectories
-        export EMACSLOADPATH="/home/linuxbrew/.linuxbrew/opt/emacs-app-linux/share/emacs/#{emacs_version}/lisp:"
-      else
-        export EMACSDATA="$SCRIPT_DIR/share/emacs/#{emacs_version}/etc"
-        export EMACSPATH="$SCRIPT_DIR/bin"
-        export EMACSDOC="$SCRIPT_DIR/share/emacs/#{emacs_version}/etc"
-        export EMACSLOADPATH="$SCRIPT_DIR/share/emacs/#{emacs_version}/lisp:"
-      fi
-    ENVVARS
-
-    content.gsub!(
-      'export GSETTINGS_SCHEMA_DIR="$SCRIPT_DIR/share/glib-2.0/schemas"',
-      emacs_env_vars.strip,
-    )
-
-    File.write(script_path, content)
-  end
-
-  postflight do
-    # Create necessary directories
-    FileUtils.mkdir_p "#{Dir.home}/.local/share/applications"
-    FileUtils.mkdir_p "#{Dir.home}/.local/share/icons/hicolor"
-    FileUtils.mkdir_p "#{Dir.home}/.local/share/glib-2.0/schemas"
-
-    emacs_root = "#{HOMEBREW_PREFIX}/opt/emacs-app-linux"
-
-    # Copy compiled gschemas
-    if File.exist?("#{emacs_root}/share/glib-2.0/schemas/gschemas.compiled")
-      FileUtils.cp(
-        "#{emacs_root}/share/glib-2.0/schemas/gschemas.compiled",
-        "#{Dir.home}/.local/share/glib-2.0/schemas/",
-      )
-      FileUtils.cp(
-        "#{emacs_root}/share/glib-2.0/schemas/org.gnu.emacs.defaults.gschema.xml",
-        "#{Dir.home}/.local/share/glib-2.0/schemas/",
-      )
-    end
-
-    # Copy icons to user directory
-    icon_sizes = %w[16x16 24x24 32x32 48x48 128x128 scalable]
-    icon_sizes.each do |size|
-      src_icon = "#{emacs_root}/share/icons/hicolor/#{size}/apps/emacs.png"
-      src_icon = "#{emacs_root}/share/icons/hicolor/#{size}/apps/emacs.svg" if size == "scalable"
-
-      if File.exist?(src_icon)
-        FileUtils.mkdir_p "#{Dir.home}/.local/share/icons/hicolor/#{size}/apps"
-        FileUtils.cp(src_icon, "#{Dir.home}/.local/share/icons/hicolor/#{size}/apps/")
-      end
-    end
-
-    # Update icon cache if available
-    if system("which gtk-update-icon-cache > /dev/null 2>&1")
-      system "gtk-update-icon-cache", "#{Dir.home}/.local/share/icons/hicolor", "-f",
-             "-t"
-    end
-
-    # Install desktop files with corrected Exec paths
-    emacs_version = version.split("-").first
-    emacs_wm_class = "emacs-#{emacs_version.tr(".", "-")}"
-    desktop_files = %w[emacs emacsclient emacs-mail emacsclient-mail]
-    desktop_files.each do |desktop_name|
-      src_desktop = "#{emacs_root}/share/applications/#{desktop_name}.desktop"
-      next unless File.exist?(src_desktop)
-
-      desktop_content = File.read(src_desktop)
-      # Fix Exec paths to use homebrew bin directory
-      desktop_content.gsub!("Exec=emacs", "Exec=#{HOMEBREW_PREFIX}/bin/emacs")
-      desktop_content.gsub!(%r{Exec=/usr/local/bin/emacs}, "Exec=#{HOMEBREW_PREFIX}/bin/emacs")
-      desktop_content.gsub!(%r{Exec=/usr/local/bin/emacsclient}, "Exec=#{HOMEBREW_PREFIX}/bin/emacsclient")
-      desktop_content.gsub!("Exec=emacsclient", "Exec=#{HOMEBREW_PREFIX}/bin/emacsclient")
-
-      # Only set StartupWMClass on emacs.desktop so the window matches the
-      # correct launcher. Remove it from other desktop files to prevent them
-      # from claiming the Emacs window.
-      if desktop_name == "emacs"
-        if desktop_content.match?(/^StartupWMClass=/i)
-          # Replace any existing StartupWMClass line.
-          desktop_content.gsub!(/^StartupWMClass=.*/i, "StartupWMClass=#{emacs_wm_class}")
-        elsif desktop_content.sub!(/^StartupNotify=.*$/i) { |line| "#{line}\nStartupWMClass=#{emacs_wm_class}" }
-          # Inserted after StartupNotify.
-        elsif desktop_content.sub!(/^Categories=.*$/i) { |line| "StartupWMClass=#{emacs_wm_class}\n#{line}" }
-          # Inserted before Categories.
+      wm_class="emacs-$(printf '%s' "$emacs_version" | tr . -)"
+      for name in emacs emacsclient emacs-mail emacsclient-mail; do
+        desktop="$payload/share/applications/$name.desktop"
+        [ -f "$desktop" ] || continue
+        sed -i \
+          -e 's#Exec=emacs#Exec={{HOMEBREW_PREFIX}}/bin/emacs#g' \
+          -e 's#Exec=/usr/local/bin/emacs#Exec={{HOMEBREW_PREFIX}}/bin/emacs#g' \
+          -e 's#Exec=/usr/local/bin/emacsclient#Exec={{HOMEBREW_PREFIX}}/bin/emacsclient#g' \
+          -e 's#Exec=emacsclient#Exec={{HOMEBREW_PREFIX}}/bin/emacsclient#g' "$desktop"
+        if [ "$name" != emacs ]; then
+          sed -i '/^StartupWMClass=.*/Id' "$desktop"
+        elif grep -qi '^StartupWMClass=' "$desktop"; then
+          sed -i "s/^StartupWMClass=.*/StartupWMClass=$wm_class/I" "$desktop"
+        elif grep -qi '^StartupNotify=' "$desktop"; then
+          sed -i "0,/^StartupNotify=.*$/Is//&\nStartupWMClass=$wm_class/" "$desktop"
+        elif grep -qi '^Categories=' "$desktop"; then
+          sed -i "0,/^Categories=.*$/Is//StartupWMClass=$wm_class\n&/" "$desktop"
         else
-          # Fallback: append at end if neither StartupNotify nor Categories exists.
-          desktop_content << "\nStartupWMClass=#{emacs_wm_class}\n"
-        end
-      else
-        desktop_content.gsub!(/^StartupWMClass=.*\n?/i, "")
-      end
+          printf '\nStartupWMClass=%s\n' "$wm_class" >> "$desktop"
+        fi
+      done
+    SH
+    # Linux sandbox setup creates the future inreplace path as a directory.
+    # Clear that cask-owned placeholder before moving the extracted payload.
+    remove "emacs", recursive: true
+    move "emacs-pgtk-*-fedora-latest-*", "emacs", source_glob: true
+    set_permissions "emacs/run-emacs.sh", "+x"
 
-      File.write("#{Dir.home}/.local/share/applications/#{desktop_name}.desktop", desktop_content)
+    inreplace(
+      "emacs/run-emacs.sh",
+      %r{# Add Homebrew paths.*?\n  export LD_LIBRARY_PATH="/home/linuxbrew/\.linuxbrew/lib:\$LD_LIBRARY_PATH"\nfi}m,
+      <<~PATHS,
+        # Add Homebrew paths if they exist (for systems like immutable distros)
+        if [ -d "{{HOMEBREW_PREFIX}}/lib" ]; then
+          export LD_LIBRARY_PATH="{{HOMEBREW_PREFIX}}/lib:$LD_LIBRARY_PATH"
+        fi
+        # Add libgccjit (required for native compilation)
+        if [ -d "{{HOMEBREW_PREFIX}}/opt/libgccjit/lib/gcc/current" ]; then
+          export LD_LIBRARY_PATH="{{HOMEBREW_PREFIX}}/opt/libgccjit/lib/gcc/current:$LD_LIBRARY_PATH"
+        fi
+        # Add tree-sitter@0.25 (keg-only)
+        if [ -d "{{HOMEBREW_PREFIX}}/opt/tree-sitter@0.25/lib" ]; then
+          export LD_LIBRARY_PATH="{{HOMEBREW_PREFIX}}/opt/tree-sitter@0.25/lib:$LD_LIBRARY_PATH"
+        fi
+      PATHS
+      audit_result: false,
+    )
+    inreplace "emacs/run-emacs.sh",
+              'export GSETTINGS_SCHEMA_DIR="$SCRIPT_DIR/share/glib-2.0/schemas"',
+              <<~ENVVARS, audit_result: false
+                export GSETTINGS_SCHEMA_DIR="$SCRIPT_DIR/share/glib-2.0/schemas"
+                . "{{staged_path}}/emacs/emacs-paths.sh"
+
+                # Use the linked opt tree, or fall back to the staged data.
+                if [ -d "{{HOMEBREW_PREFIX}}/opt/emacs-app-linux/share/emacs/$emacs_version" ]; then
+                  export EMACSDATA="{{HOMEBREW_PREFIX}}/opt/emacs-app-linux/share/emacs/$emacs_version/etc"
+                  export EMACSPATH="{{HOMEBREW_PREFIX}}/opt/emacs-app-linux/libexec/emacs/$emacs_version/$target_triplet"
+                  export EMACSDOC="{{HOMEBREW_PREFIX}}/opt/emacs-app-linux/share/emacs/$emacs_version/etc"
+                  export EMACSLOADPATH="{{HOMEBREW_PREFIX}}/opt/emacs-app-linux/share/emacs/$emacs_version/lisp:"
+                else
+                  export EMACSDATA="$SCRIPT_DIR/share/emacs/$emacs_version/etc"
+                  export EMACSPATH="$SCRIPT_DIR/bin"
+                  export EMACSDOC="$SCRIPT_DIR/share/emacs/$emacs_version/etc"
+                  export EMACSLOADPATH="$SCRIPT_DIR/share/emacs/$emacs_version/lisp:"
+                fi
+              ENVVARS
+  end
+
+  postflight_steps do
+    mkdir_p ".local/share/applications", base: :home
+    mkdir_p ".local/share/icons/hicolor", base: :home
+    mkdir_p ".local/share/glib-2.0/schemas", base: :home
+
+    if_path_exists "opt/emacs-app-linux/share/glib-2.0/schemas/gschemas.compiled", base: :homebrew_prefix do
+      copy "opt/emacs-app-linux/share/glib-2.0/schemas/gschemas.compiled",
+           ".local/share/glib-2.0/schemas/gschemas.compiled", source_base: :homebrew_prefix, target_base: :home
+      copy "opt/emacs-app-linux/share/glib-2.0/schemas/org.gnu.emacs.defaults.gschema.xml",
+           ".local/share/glib-2.0/schemas/org.gnu.emacs.defaults.gschema.xml",
+           source_base: :homebrew_prefix, target_base: :home
     end
 
-    # Update desktop database if available
-    if system("which update-desktop-database > /dev/null 2>&1")
-      system "update-desktop-database",
-             "#{Dir.home}/.local/share/applications"
+    if_path_exists "opt/emacs-app-linux/share/icons/hicolor/16x16/apps/emacs.png", base: :homebrew_prefix do
+      copy "opt/emacs-app-linux/share/icons/hicolor/16x16/apps/emacs.png",
+           ".local/share/icons/hicolor/16x16/apps/emacs.png", source_base: :homebrew_prefix, target_base: :home
+    end
+    if_path_exists "opt/emacs-app-linux/share/icons/hicolor/24x24/apps/emacs.png", base: :homebrew_prefix do
+      copy "opt/emacs-app-linux/share/icons/hicolor/24x24/apps/emacs.png",
+           ".local/share/icons/hicolor/24x24/apps/emacs.png", source_base: :homebrew_prefix, target_base: :home
+    end
+    if_path_exists "opt/emacs-app-linux/share/icons/hicolor/32x32/apps/emacs.png", base: :homebrew_prefix do
+      copy "opt/emacs-app-linux/share/icons/hicolor/32x32/apps/emacs.png",
+           ".local/share/icons/hicolor/32x32/apps/emacs.png", source_base: :homebrew_prefix, target_base: :home
+    end
+    if_path_exists "opt/emacs-app-linux/share/icons/hicolor/48x48/apps/emacs.png", base: :homebrew_prefix do
+      copy "opt/emacs-app-linux/share/icons/hicolor/48x48/apps/emacs.png",
+           ".local/share/icons/hicolor/48x48/apps/emacs.png", source_base: :homebrew_prefix, target_base: :home
+    end
+    if_path_exists "opt/emacs-app-linux/share/icons/hicolor/128x128/apps/emacs.png", base: :homebrew_prefix do
+      copy "opt/emacs-app-linux/share/icons/hicolor/128x128/apps/emacs.png",
+           ".local/share/icons/hicolor/128x128/apps/emacs.png", source_base: :homebrew_prefix, target_base: :home
+    end
+    if_path_exists "opt/emacs-app-linux/share/icons/hicolor/scalable/apps/emacs.svg", base: :homebrew_prefix do
+      copy "opt/emacs-app-linux/share/icons/hicolor/scalable/apps/emacs.svg",
+           ".local/share/icons/hicolor/scalable/apps/emacs.svg", source_base: :homebrew_prefix, target_base: :home
+    end
+
+    if_path_exists "opt/emacs-app-linux/share/applications/emacs.desktop", base: :homebrew_prefix do
+      copy "opt/emacs-app-linux/share/applications/emacs.desktop", ".local/share/applications/emacs.desktop",
+           source_base: :homebrew_prefix, target_base: :home
+    end
+    if_path_exists "opt/emacs-app-linux/share/applications/emacsclient.desktop", base: :homebrew_prefix do
+      copy "opt/emacs-app-linux/share/applications/emacsclient.desktop",
+           ".local/share/applications/emacsclient.desktop", source_base: :homebrew_prefix, target_base: :home
+    end
+    if_path_exists "opt/emacs-app-linux/share/applications/emacs-mail.desktop", base: :homebrew_prefix do
+      copy "opt/emacs-app-linux/share/applications/emacs-mail.desktop",
+           ".local/share/applications/emacs-mail.desktop", source_base: :homebrew_prefix, target_base: :home
+    end
+    if_path_exists "opt/emacs-app-linux/share/applications/emacsclient-mail.desktop", base: :homebrew_prefix do
+      copy "opt/emacs-app-linux/share/applications/emacsclient-mail.desktop",
+           ".local/share/applications/emacsclient-mail.desktop", source_base: :homebrew_prefix, target_base: :home
+    end
+
+    mkdir_p "emacs-user-data"
+    symlink ".local/share", "emacs-user-data/share", source_base: :home, overwrite: true
+    if_path_exists "gtk-update-icon-cache", base: :search_path do
+      run "gtk-update-icon-cache", args: ["{{staged_path}}/emacs-user-data/share/icons/hicolor", "-f", "-t"],
+                                   must_succeed: false,
+                                   writable_paths: [".local/share/icons/hicolor"], writable_base: :home
+    end
+    if_path_exists "update-desktop-database", base: :search_path do
+      run "update-desktop-database", args: ["{{staged_path}}/emacs-user-data/share/applications"],
+                                     must_succeed: false,
+                                     writable_paths: [".local/share/applications"], writable_base: :home
     end
   end
 
-  uninstall_postflight do
-    # Clean up desktop files
-    %w[emacs emacsclient emacs-mail emacsclient-mail].each do |desktop_name|
-      FileUtils.rm("#{Dir.home}/.local/share/applications/#{desktop_name}.desktop")
-    end
+  uninstall_postflight_steps do
+    remove [
+      ".local/share/applications/emacs.desktop",
+      ".local/share/applications/emacsclient.desktop",
+      ".local/share/applications/emacs-mail.desktop",
+      ".local/share/applications/emacsclient-mail.desktop",
+      ".local/share/icons/hicolor/16x16/apps/emacs.png",
+      ".local/share/icons/hicolor/24x24/apps/emacs.png",
+      ".local/share/icons/hicolor/32x32/apps/emacs.png",
+      ".local/share/icons/hicolor/48x48/apps/emacs.png",
+      ".local/share/icons/hicolor/128x128/apps/emacs.png",
+      ".local/share/icons/hicolor/scalable/apps/emacs.svg",
+      ".local/share/glib-2.0/schemas/gschemas.compiled",
+      ".local/share/glib-2.0/schemas/org.gnu.emacs.defaults.gschema.xml",
+    ], base: :home
 
-    # Clean up icons
-    icon_sizes = %w[16x16 24x24 32x32 48x48 128x128 scalable]
-    icon_sizes.each do |size|
-      icon_ext = (size == "scalable") ? "svg" : "png"
-      FileUtils.rm("#{Dir.home}/.local/share/icons/hicolor/#{size}/apps/emacs.#{icon_ext}")
+    mkdir_p "emacs-user-data"
+    symlink ".local/share", "emacs-user-data/share", source_base: :home, overwrite: true
+    if_path_exists "gtk-update-icon-cache", base: :search_path do
+      run "gtk-update-icon-cache", args: ["{{staged_path}}/emacs-user-data/share/icons/hicolor", "-f", "-t"],
+                                   must_succeed: false,
+                                   writable_paths: [".local/share/icons/hicolor"], writable_base: :home
     end
-
-    # Clean up gschemas
-    FileUtils.rm("#{Dir.home}/.local/share/glib-2.0/schemas/gschemas.compiled")
-    FileUtils.rm("#{Dir.home}/.local/share/glib-2.0/schemas/org.gnu.emacs.defaults.gschema.xml")
-
-    # Update caches
-    if system("which gtk-update-icon-cache > /dev/null 2>&1")
-      system "gtk-update-icon-cache", "#{Dir.home}/.local/share/icons/hicolor", "-f",
-             "-t"
-    end
-    if system("which update-desktop-database > /dev/null 2>&1")
-      system "update-desktop-database",
-             "#{Dir.home}/.local/share/applications"
+    if_path_exists "update-desktop-database", base: :search_path do
+      run "update-desktop-database", args: ["{{staged_path}}/emacs-user-data/share/applications"],
+                                     must_succeed: false,
+                                     writable_paths: [".local/share/applications"], writable_base: :home
     end
   end
 end

--- a/Casks/emdash-linux.rb
+++ b/Casks/emdash-linux.rb
@@ -20,27 +20,24 @@ cask "emdash-linux" do
   artifact "squashfs-root/emdash.desktop",
            target: "#{Dir.home}/.local/share/applications/emdash.desktop"
 
-  preflight do
-    appimage_path = "#{staged_path}/emdash-x86_64.AppImage"
-    system "chmod", "+x", appimage_path
-    system appimage_path, "--appimage-extract", chdir: staged_path
-    FileUtils.rm(appimage_path)
+  preflight_steps do
+    # Normalise the AppImage filename before extraction.
+    move "emdash-x86_64.AppImage", "emdash.AppImage"
+    set_permissions "emdash.AppImage", "+x"
+    run "emdash.AppImage", args: ["--appimage-extract"], base: :staged_path, chdir: "{{staged_path}}"
+    remove "emdash.AppImage"
   end
 
-  postflight do
-    desktop_target = "#{Dir.home}/.local/share/applications/emdash.desktop"
-    if File.exist?(desktop_target)
-      desktop_content = File.read(desktop_target)
-      desktop_content.gsub!(/^Exec=AppRun/, "Exec=#{HOMEBREW_PREFIX}/bin/emdash")
-      desktop_content.gsub!(/^Icon=.*/,
-                            "Icon=#{Dir.home}/.local/share/icons/hicolor/512x512/apps/emdash.png")
-      File.write(desktop_target, desktop_content)
-    end
+  postflight_steps do
+    inreplace ".local/share/applications/emdash.desktop", /^Exec=AppRun/,
+              "Exec={{HOMEBREW_PREFIX}}/bin/emdash", base: :home, audit_result: false
+    inreplace ".local/share/applications/emdash.desktop", /^Icon=.*/,
+              "Icon=emdash", base: :home, audit_result: false
   end
 
-  uninstall_postflight do
-    FileUtils.rm("#{Dir.home}/.local/share/icons/hicolor/512x512/apps/emdash.png")
-    FileUtils.rm("#{Dir.home}/.local/share/applications/emdash.desktop")
+  uninstall_postflight_steps do
+    remove ".local/share/icons/hicolor/512x512/apps/emdash.png", base: :home
+    remove ".local/share/applications/emdash.desktop", base: :home
   end
 
   zap trash: "~/.config/emdash"

--- a/Casks/fw-fanctrl-linux.rb
+++ b/Casks/fw-fanctrl-linux.rb
@@ -22,130 +22,131 @@ cask "fw-fanctrl-linux" do
     end
   end
 
-  binary "#{release_root}/usr/bin/fw-fanctrl"
-  binary "#{release_root}/usr/bin/ectool"
+  binary "release/usr/bin/fw-fanctrl"
+  binary "release/usr/bin/ectool"
 
-  postflight do
-    release_dir = "#{staged_path}/#{release_root}"
-    root_prefix = "/opt/ublue-fw-fanctrl"
-    root_bin_dir = "#{root_prefix}/bin"
-    systemd_dir = "/etc/systemd/system"
-    sleep_dir = "/etc/systemd/system-sleep"
-    config_dir = "/etc/fw-fanctrl"
-
-    service_src = "#{release_dir}/usr/lib/systemd/system/fw-fanctrl.service"
-    sleep_src = "#{release_dir}/usr/lib/systemd/system-sleep/fw-fanctrl-suspend"
-    config_src = "#{release_dir}/usr/share/fw-fanctrl/config.json"
-    schema_src = "#{release_dir}/usr/share/fw-fanctrl/config.schema.json"
-
-    getenforce = %w[/usr/sbin/getenforce /usr/bin/getenforce /bin/getenforce].find do |path|
-      File.executable?(path)
-    end
-    restorecon = %w[/usr/sbin/restorecon /usr/bin/restorecon /bin/restorecon].find do |path|
-      File.executable?(path)
-    end
-    semanage = %w[/usr/sbin/semanage /usr/bin/semanage /bin/semanage].find do |path|
-      File.executable?(path)
-    end
-    chcon = %w[/usr/sbin/chcon /usr/bin/chcon /bin/chcon].find do |path|
-      File.executable?(path)
-    end
-    systemctl = %w[/usr/bin/systemctl /bin/systemctl].find do |path|
-      File.executable?(path)
-    end
-
-    ohai "Installing fw-fanctrl payload under #{root_prefix}"
-
-    system "sudo", "install", "-d",
-           root_bin_dir, systemd_dir, sleep_dir, config_dir
-
-    system "sudo", "install", "-Dm0755",
-           "#{release_dir}/usr/bin/fw-fanctrl",
-           "#{root_bin_dir}/fw-fanctrl"
-    system "sudo", "install", "-Dm0755",
-           "#{release_dir}/usr/bin/ectool",
-           "#{root_bin_dir}/ectool"
-
-    system "sudo", "install", "-Dm0644",
-           service_src,
-           "#{systemd_dir}/fw-fanctrl.service"
-    system "sudo", "install", "-Dm0755",
-           sleep_src,
-           "#{sleep_dir}/fw-fanctrl-suspend"
-    system "sudo", "install", "-Dm0644",
-           schema_src,
-           "#{config_dir}/config.schema.json"
-
-    unless File.exist?("#{config_dir}/config.json")
-      system "sudo", "install", "-Dm0644",
-             config_src,
-             "#{config_dir}/config.json"
-    end
-
-    selinux_mode = if getenforce
-      IO.popen([getenforce], &:read).strip
-    else
-      "Disabled"
-    end
-
-    if selinux_mode != "Disabled"
-      bin_pattern = "#{root_bin_dir}(/.*)?"
-
-      if semanage
-        added = system "sudo", semanage, "fcontext", "-a", "-t", "bin_t", bin_pattern
-        system "sudo", semanage, "fcontext", "-m", "-t", "bin_t", bin_pattern unless added
-      elsif chcon
-        system "sudo", chcon, "-R", "-t", "bin_t", root_bin_dir
-      end
-
-      if restorecon
-        [root_prefix, systemd_dir, sleep_dir, config_dir].each do |path|
-          system "sudo", restorecon, "-RFv", path if File.exist?(path)
-        end
-      end
-    end
-
-    system "sudo", systemctl, "daemon-reload" if systemctl
+  preflight_steps do
+    # Normalise the versioned payload directory before install.
+    move "fw-fanctrl-*", "release", source_glob: true
   end
 
-  uninstall_preflight do
-    root_prefix = "/opt/ublue-fw-fanctrl"
-    root_bin_dir = "#{root_prefix}/bin"
-    systemd_dir = "/etc/systemd/system"
-    sleep_dir = "/etc/systemd/system-sleep"
-    config_dir = "/etc/fw-fanctrl"
+  postflight_steps do
+    # The payload is installed under canonical system paths via a sudo-brokered
+    # shell step. Commands mirror the original `system("sudo", ...)` calls,
+    # which ignore non-zero exits, so the script does not `set -e`; failures
+    # inside are tolerated exactly as the legacy code tolerated them.
+    run "sh",
+        sudo: true,
+        args: ["-c", <<~SH]
+          root_prefix="/opt/ublue-fw-fanctrl"
+          root_bin_dir="$root_prefix/bin"
+          systemd_dir="/etc/systemd/system"
+          sleep_dir="/etc/systemd/system-sleep"
+          config_dir="/etc/fw-fanctrl"
+          release_dir="{{staged_path}}/release"
 
-    getenforce = %w[/usr/sbin/getenforce /usr/bin/getenforce /bin/getenforce].find do |path|
-      File.executable?(path)
-    end
-    restorecon = %w[/usr/sbin/restorecon /usr/bin/restorecon /bin/restorecon].find do |path|
-      File.executable?(path)
-    end
-    semanage = %w[/usr/sbin/semanage /usr/bin/semanage /bin/semanage].find do |path|
-      File.executable?(path)
-    end
-    systemctl = %w[/usr/bin/systemctl /bin/systemctl].find do |path|
-      File.executable?(path)
-    end
+          service_src="$release_dir/usr/lib/systemd/system/fw-fanctrl.service"
+          sleep_src="$release_dir/usr/lib/systemd/system-sleep/fw-fanctrl-suspend"
+          config_src="$release_dir/usr/share/fw-fanctrl/config.json"
+          schema_src="$release_dir/usr/share/fw-fanctrl/config.schema.json"
 
-    system "sudo", systemctl, "disable", "--now", "fw-fanctrl.service" if systemctl
+          getenforce_cmd=""; for p in /usr/sbin/getenforce /usr/bin/getenforce /bin/getenforce; do
+            [ -x "$p" ] && getenforce_cmd="$p" && break; done
+          restorecon_cmd=""; for p in /usr/sbin/restorecon /usr/bin/restorecon /bin/restorecon; do
+            [ -x "$p" ] && restorecon_cmd="$p" && break; done
+          semanage_cmd=""; for p in /usr/sbin/semanage /usr/bin/semanage /bin/semanage; do
+            [ -x "$p" ] && semanage_cmd="$p" && break; done
+          chcon_cmd=""; for p in /usr/sbin/chcon /usr/bin/chcon /bin/chcon; do
+            [ -x "$p" ] && chcon_cmd="$p" && break; done
+          systemctl_cmd=""; for p in /usr/bin/systemctl /bin/systemctl; do
+            [ -x "$p" ] && systemctl_cmd="$p" && break; done
 
-    selinux_mode = if getenforce
-      IO.popen([getenforce], &:read).strip
-    else
-      "Disabled"
-    end
+          install -d "$root_bin_dir" "$systemd_dir" "$sleep_dir" "$config_dir"
+          install -Dm0755 "$release_dir/usr/bin/fw-fanctrl" "$root_bin_dir/fw-fanctrl"
+          install -Dm0755 "$release_dir/usr/bin/ectool" "$root_bin_dir/ectool"
+          install -Dm0644 "$service_src" "$systemd_dir/fw-fanctrl.service"
+          install -Dm0755 "$sleep_src" "$sleep_dir/fw-fanctrl-suspend"
+          install -Dm0644 "$schema_src" "$config_dir/config.schema.json"
+          if [ ! -f "$config_dir/config.json" ]; then
+            install -Dm0644 "$config_src" "$config_dir/config.json"
+          fi
 
-    system "sudo", semanage, "fcontext", "-d", "#{root_bin_dir}(/.*)?" if selinux_mode != "Disabled" && semanage
+          if [ -n "$getenforce_cmd" ]; then
+            selinux_mode="$("$getenforce_cmd" 2>/dev/null)"
+          else
+            selinux_mode="Disabled"
+          fi
+          selinux_mode="${selinux_mode:-Disabled}"
 
-    system "sudo", "rm", "-f", "#{systemd_dir}/fw-fanctrl.service"
-    system "sudo", "rm", "-f", "#{sleep_dir}/fw-fanctrl-suspend"
-    system "sudo", "rm", "-f", "#{config_dir}/config.schema.json"
-    system "sudo", "rm", "-rf", root_prefix
-    system "sudo", "rmdir", config_dir if Dir.exist?(config_dir) && Dir.empty?(config_dir)
+          if [ "$selinux_mode" != "Disabled" ]; then
+            bin_pattern="$root_bin_dir(/.*)?"
+            if [ -n "$semanage_cmd" ]; then
+              if "$semanage_cmd" fcontext -a -t bin_t "$bin_pattern" 2>/dev/null; then
+                :
+              else
+                "$semanage_cmd" fcontext -m -t bin_t "$bin_pattern" 2>/dev/null || true
+              fi
+            elif [ -n "$chcon_cmd" ]; then
+              "$chcon_cmd" -R -t bin_t "$root_bin_dir" 2>/dev/null || true
+            fi
+            if [ -n "$restorecon_cmd" ]; then
+              for path in "$root_prefix" "$systemd_dir" "$sleep_dir" "$config_dir"; do
+                [ -e "$path" ] && "$restorecon_cmd" -RFv "$path" 2>/dev/null || true
+              done
+            fi
+          fi
 
-    system "sudo", systemctl, "daemon-reload" if systemctl
-    system "sudo", restorecon, "-RFv", "/opt", "/var/opt" if restorecon && selinux_mode != "Disabled"
+          [ -z "$systemctl_cmd" ] || "$systemctl_cmd" daemon-reload 2>/dev/null || true
+        SH
+  end
+
+  uninstall_preflight_steps do
+    # The payload is removed under canonical system paths via a sudo-brokered
+    # shell step. Commands mirror the original `system("sudo", ...)` semantics
+    # (errors ignored), so the script does not `set -e`.
+    run "sh",
+        sudo: true,
+        args: ["-c", <<~SH]
+          root_prefix="/opt/ublue-fw-fanctrl"
+          root_bin_dir="$root_prefix/bin"
+          systemd_dir="/etc/systemd/system"
+          sleep_dir="/etc/systemd/system-sleep"
+          config_dir="/etc/fw-fanctrl"
+
+          getenforce_cmd=""; for p in /usr/sbin/getenforce /usr/bin/getenforce /bin/getenforce; do
+            [ -x "$p" ] && getenforce_cmd="$p" && break; done
+          restorecon_cmd=""; for p in /usr/sbin/restorecon /usr/bin/restorecon /bin/restorecon; do
+            [ -x "$p" ] && restorecon_cmd="$p" && break; done
+          semanage_cmd=""; for p in /usr/sbin/semanage /usr/bin/semanage /bin/semanage; do
+            [ -x "$p" ] && semanage_cmd="$p" && break; done
+          systemctl_cmd=""; for p in /usr/bin/systemctl /bin/systemctl; do
+            [ -x "$p" ] && systemctl_cmd="$p" && break; done
+
+          [ -z "$systemctl_cmd" ] || "$systemctl_cmd" disable --now fw-fanctrl.service 2>/dev/null
+
+          if [ -n "$getenforce_cmd" ]; then
+            selinux_mode="$("$getenforce_cmd" 2>/dev/null)"
+          else
+            selinux_mode="Disabled"
+          fi
+          selinux_mode="${selinux_mode:-Disabled}"
+          if [ "$selinux_mode" != "Disabled" ] && [ -n "$semanage_cmd" ]; then
+            "$semanage_cmd" fcontext -d "$root_bin_dir(/.*)?" 2>/dev/null || true
+          fi
+
+          rm -f "$systemd_dir/fw-fanctrl.service"
+          rm -f "$sleep_dir/fw-fanctrl-suspend"
+          rm -f "$config_dir/config.schema.json"
+          rm -rf "$root_prefix"
+          if [ -d "$config_dir" ] && [ -z "$(ls -A "$config_dir" 2>/dev/null)" ]; then
+            rmdir "$config_dir" 2>/dev/null || true
+          fi
+
+          [ -z "$systemctl_cmd" ] || "$systemctl_cmd" daemon-reload 2>/dev/null || true
+          if [ -n "$restorecon_cmd" ] && [ "$selinux_mode" != "Disabled" ]; then
+            "$restorecon_cmd" -RFv /opt /var/opt 2>/dev/null || true
+          fi
+        SH
   end
 
   caveats <<~EOS

--- a/Casks/ghostty-linux.rb
+++ b/Casks/ghostty-linux.rb
@@ -20,63 +20,78 @@ cask "ghostty-linux" do
 
   binary "ghostty-wrapper", target: "ghostty"
 
-  preflight do
-    appimage_path = "#{staged_path}/Ghostty-#{version}-#{arch}.AppImage"
-    system "chmod", "+x", appimage_path
-    system appimage_path, "--appimage-extract", chdir: staged_path
+  preflight_steps do
+    # Normalise the arch/version-specific AppImage filename before extraction.
+    move "Ghostty-*.AppImage", "ghostty.AppImage", source_glob: true
+    set_permissions "ghostty.AppImage", "+x"
+    run "ghostty.AppImage", args: ["--appimage-extract"], base: :staged_path,
+        chdir: "{{staged_path}}"
+    remove "ghostty.AppImage"
 
-    # Remove the original AppImage to save space
-    FileUtils.rm appimage_path
-
-    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
-    FileUtils.mkdir_p "#{xdg_data}/applications"
+    mkdir_p ".local/share/applications", base: :home
 
     # Create wrapper script to execute AppRun from the correct directory
     # (upstream switched from binary AppRun to shell script in v1.2.3 which
     # breaks symlinks since it uses $0's directory to find resources)
-    wrapper_content = <<~SH
+    write_file "ghostty-wrapper", <<~SH
       #!/bin/sh
-      exec "#{staged_path}/squashfs-root/AppRun" "$@"
+      exec "{{staged_path}}/squashfs-root/AppRun" "$@"
     SH
-    File.write("#{staged_path}/ghostty-wrapper", wrapper_content)
-    FileUtils.chmod(0755, "#{staged_path}/ghostty-wrapper")
+    set_permissions "ghostty-wrapper", "0755"
   end
 
-  postflight do
-    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
-
+  postflight_steps do
     # keep the app-id filename (GNOME window matching) and the Exec arguments;
     # disable D-Bus activation since the bundled service file execs a CI path
-    desktop_content = File.read("#{staged_path}/squashfs-root/com.mitchellh.ghostty.desktop")
-    desktop_content.gsub!(/^TryExec=\S+/, "TryExec=#{HOMEBREW_PREFIX}/bin/ghostty")
-    desktop_content.gsub!(/^Exec=\S+/, "Exec=#{HOMEBREW_PREFIX}/bin/ghostty")
-    desktop_content.gsub!(/^DBusActivatable=true$/, "DBusActivatable=false")
-    File.write("#{xdg_data}/applications/com.mitchellh.ghostty.desktop", desktop_content)
+    copy "squashfs-root/com.mitchellh.ghostty.desktop",
+         ".local/share/applications/com.mitchellh.ghostty.desktop", target_base: :home
+    inreplace ".local/share/applications/com.mitchellh.ghostty.desktop", /^TryExec=\S+/,
+              "TryExec={{HOMEBREW_PREFIX}}/bin/ghostty", base: :home, audit_result: false
+    inreplace ".local/share/applications/com.mitchellh.ghostty.desktop", /^Exec=\S+/,
+              "Exec={{HOMEBREW_PREFIX}}/bin/ghostty", base: :home, audit_result: false
+    inreplace ".local/share/applications/com.mitchellh.ghostty.desktop", /^DBusActivatable=true$/,
+              "DBusActivatable=false", base: :home, audit_result: false
 
-    # install icons under the name the desktop file's Icon= key references
-    Dir["#{staged_path}/squashfs-root/share/icons/hicolor/*/apps/com.mitchellh.ghostty.png"].each do |icon|
-      size = File.basename(File.dirname(icon, 2))
-      target_dir = "#{xdg_data}/icons/hicolor/#{size}/apps"
-      FileUtils.mkdir_p target_dir
-      FileUtils.cp(icon, "#{target_dir}/com.mitchellh.ghostty.png")
-    end
-    system "gtk-update-icon-cache", "-f", "-t", "#{xdg_data}/icons/hicolor"
+    # Copy every discovered icon size through a staged handle onto the narrowly
+    # writable hicolor tree, mirroring the original per-size loop.
+    mkdir_p ".local/share/icons/hicolor", base: :home
+    mkdir_p "ghostty-user-data"
+    symlink ".local/share", "ghostty-user-data/share", source_base: :home, overwrite: true
+    write_file "install-ghostty-icons.sh", <<~SH
+      #!/bin/sh
+      for icon in "{{staged_path}}"/squashfs-root/share/icons/hicolor/*/apps/com.mitchellh.ghostty.png; do
+        [ -f "$icon" ] || continue
+        size=$(basename "$(dirname "$(dirname "$icon")")")
+        target="{{staged_path}}/ghostty-user-data/share/icons/hicolor/$size/apps"
+        mkdir -p "$target"
+        cp "$icon" "$target/com.mitchellh.ghostty.png"
+      done
+    SH
+    set_permissions "install-ghostty-icons.sh", "0755"
+    run "install-ghostty-icons.sh", base: :staged_path,
+                                    writable_paths: [".local/share/icons/hicolor"], writable_base: :home
+    run "gtk-update-icon-cache", args: ["-f", "-t", "{{staged_path}}/ghostty-user-data/share/icons/hicolor"],
+                                 must_succeed: false,
+                                 writable_paths: [".local/share/icons/hicolor"], writable_base: :home
 
     # clean up files older cask revisions installed under wrong names/locations
-    FileUtils.rm("#{xdg_data}/applications/ghostty.desktop", force: true)
-    FileUtils.rm("#{xdg_data}/icons/ghostty.png", force: true)
-    FileUtils.rm("#{xdg_data}/systemd/user/com.mitchellh.ghostty.service", force: true)
+    remove ".local/share/applications/ghostty.desktop", base: :home
+    remove ".local/share/icons/ghostty.png", base: :home
+    remove ".local/share/systemd/user/com.mitchellh.ghostty.service", base: :home
   end
 
-  uninstall_postflight do
-    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
-    FileUtils.rm("#{xdg_data}/applications/com.mitchellh.ghostty.desktop", force: true)
-    FileUtils.rm(Dir["#{xdg_data}/icons/hicolor/*/apps/com.mitchellh.ghostty.png"], force: true)
-    system "gtk-update-icon-cache", "-f", "-t", "#{xdg_data}/icons/hicolor"
+  uninstall_postflight_steps do
+    remove ".local/share/applications/com.mitchellh.ghostty.desktop", base: :home
+    remove ".local/share/icons/hicolor/*/apps/com.mitchellh.ghostty.png", base: :home
+    mkdir_p "ghostty-user-data"
+    symlink ".local/share", "ghostty-user-data/share", source_base: :home, overwrite: true
+    run "gtk-update-icon-cache", args: ["-f", "-t", "{{staged_path}}/ghostty-user-data/share/icons/hicolor"],
+                                 must_succeed: false,
+                                 writable_paths: [".local/share/icons/hicolor"], writable_base: :home
     # leftovers from cask revisions that installed under the wrong names
-    FileUtils.rm("#{xdg_data}/applications/ghostty.desktop", force: true)
-    FileUtils.rm("#{xdg_data}/icons/ghostty.png", force: true)
-    FileUtils.rm("#{xdg_data}/systemd/user/com.mitchellh.ghostty.service", force: true)
+    remove ".local/share/applications/ghostty.desktop", base: :home
+    remove ".local/share/icons/ghostty.png", base: :home
+    remove ".local/share/systemd/user/com.mitchellh.ghostty.service", base: :home
   end
 
   zap trash: "~/.config/ghostty"

--- a/Casks/gitkraken-linux.rb
+++ b/Casks/gitkraken-linux.rb
@@ -2,8 +2,7 @@ cask "gitkraken-linux" do
   version "12.4.0"
   sha256 "7f7e56b5bf345c1da3bcc3ff4f50bf51bf8292399f471e5c5bc2213bfafefb4d"
 
-  url "https://api.gitkraken.dev/releases/production/linux/x64/#{version}/gitkraken-amd64.tar.gz",
-      verified: "api.gitkraken.dev/releases/production/"
+  url "https://api.gitkraken.dev/releases/production/linux/x64/#{version}/gitkraken-amd64.tar.gz"
   name "GitKraken"
   desc "Git client focusing on productivity"
   homepage "https://www.gitkraken.com/"
@@ -21,15 +20,15 @@ cask "gitkraken-linux" do
   artifact "gitkraken.desktop",
            target: "#{Dir.home}/.local/share/applications/gitkraken.desktop"
 
-  preflight do
-    FileUtils.mkdir_p "#{Dir.home}/.local/share/applications"
+  preflight_steps do
+    mkdir_p ".local/share/applications", base: :home
 
-    File.write "#{staged_path}/gitkraken.desktop", <<~EOS
+    write_file "gitkraken.desktop", <<~EOS
       [Desktop Entry]
       Name=GitKraken
       Comment=Git client focusing on productivity
-      Exec=#{HOMEBREW_PREFIX}/bin/gitkraken %U
-      Icon=#{staged_path}/gitkraken/gitkraken.png
+      Exec={{HOMEBREW_PREFIX}}/bin/gitkraken %U
+      Icon={{staged_path}}/gitkraken/gitkraken.png
       Terminal=false
       Type=Application
       Categories=Development;RevisionControl;

--- a/Casks/goland-linux.rb
+++ b/Casks/goland-linux.rb
@@ -28,22 +28,25 @@ cask "goland-linux" do
   conflicts_with cask: "jetbrains-toolbox-linux"
   depends_on linux: :any
 
-  binary "#{HOMEBREW_PREFIX}/Caskroom/goland-linux/#{version}/GoLand-#{version.csv.first}/bin/goland"
+  binary "goland/bin/goland"
   artifact "jetbrains-goland.desktop",
            target: "#{Dir.home}/.local/share/applications/jetbrains-goland.desktop"
-  artifact "GoLand-#{version.csv.first}/bin/goland.svg",
+  artifact "goland/bin/goland.svg",
            target: "#{Dir.home}/.local/share/icons/hicolor/scalable/apps/goland.svg"
 
-  preflight do
-    File.write("#{staged_path}/GoLand-#{version.csv.first}/bin/goland64.vmoptions", "-Dide.no.platform.update=true\n", mode: "a+")
-    FileUtils.mkdir_p("#{Dir.home}/.local/share/applications")
-    FileUtils.mkdir_p("#{Dir.home}/.local/share/icons/hicolor/scalable/apps")
-    File.write("#{staged_path}/jetbrains-goland.desktop", <<~EOS)
+  preflight_steps do
+    # Normalise the versioned directory before referring to it in declarative steps.
+    move "GoLand-*", "goland", source_glob: true
+    touch "goland/bin/goland64.vmoptions"
+    inreplace "goland/bin/goland64.vmoptions", /\z/, "-Dide.no.platform.update=true\n"
+    mkdir_p ".local/share/applications", base: :home
+    mkdir_p ".local/share/icons/hicolor/scalable/apps", base: :home
+    write_file "jetbrains-goland.desktop", <<~EOS
       [Desktop Entry]
       Version=1.0
       Name=GoLand
       Comment=An IDE for Go and Web
-      Exec=#{HOMEBREW_PREFIX}/bin/goland %u
+      Exec={{HOMEBREW_PREFIX}}/bin/goland %u
       Icon=goland
       Type=Application
       Categories=Development;IDE;
@@ -54,8 +57,12 @@ cask "goland-linux" do
     EOS
   end
 
-  postflight do
-    system "/usr/bin/xdg-icon-resource", "forceupdate"
+  postflight_steps do
+    mkdir_p "xdg-user-data"
+    symlink ".local/share", "xdg-user-data/share", source_base: :home
+    run "/usr/bin/xdg-icon-resource", args: ["forceupdate"], must_succeed: false,
+                                  env: { "XDG_DATA_HOME" => "{{staged_path}}/xdg-user-data/share" },
+                                  writable_paths: [".local/share/icons/hicolor"], writable_base: :home
   end
 
   zap trash: [

--- a/Casks/intellij-idea-linux.rb
+++ b/Casks/intellij-idea-linux.rb
@@ -28,22 +28,25 @@ cask "intellij-idea-linux" do
   conflicts_with cask: "jetbrains-toolbox-linux"
   depends_on linux: :any
 
-  binary "#{HOMEBREW_PREFIX}/Caskroom/intellij-idea-linux/#{version}/idea-IU-#{version.csv.second}/bin/idea"
+  binary "idea/bin/idea"
   artifact "jetbrains-idea.desktop",
            target: "#{Dir.home}/.local/share/applications/jetbrains-idea.desktop"
-  artifact "idea-IU-#{version.csv.second}/bin/idea.svg",
+  artifact "idea/bin/idea.svg",
            target: "#{Dir.home}/.local/share/icons/hicolor/scalable/apps/idea.svg"
 
-  preflight do
-    File.write("#{staged_path}/idea-IU-#{version.csv.second}/bin/idea64.vmoptions", "-Dide.no.platform.update=true\n", mode: "a+")
-    FileUtils.mkdir_p("#{Dir.home}/.local/share/applications")
-    FileUtils.mkdir_p("#{Dir.home}/.local/share/icons/hicolor/scalable/apps")
-    File.write("#{staged_path}/jetbrains-idea.desktop", <<~EOS)
+  preflight_steps do
+    # Normalise the versioned directory before referring to it in declarative steps.
+    move "idea-IU-*", "idea", source_glob: true
+    touch "idea/bin/idea64.vmoptions"
+    inreplace "idea/bin/idea64.vmoptions", /\z/, "-Dide.no.platform.update=true\n"
+    mkdir_p ".local/share/applications", base: :home
+    mkdir_p ".local/share/icons/hicolor/scalable/apps", base: :home
+    write_file "jetbrains-idea.desktop", <<~EOS
       [Desktop Entry]
       Version=1.0
       Name=Intellij IDEA
       Comment=The IDE for pro Java and Kotlin development
-      Exec=#{HOMEBREW_PREFIX}/bin/idea %u
+      Exec={{HOMEBREW_PREFIX}}/bin/idea %u
       Icon=idea
       Type=Application
       Categories=Development;IDE;
@@ -54,8 +57,12 @@ cask "intellij-idea-linux" do
     EOS
   end
 
-  postflight do
-    system "/usr/bin/xdg-icon-resource", "forceupdate"
+  postflight_steps do
+    mkdir_p "xdg-user-data"
+    symlink ".local/share", "xdg-user-data/share", source_base: :home
+    run "/usr/bin/xdg-icon-resource", args: ["forceupdate"], must_succeed: false,
+                                  env: { "XDG_DATA_HOME" => "{{staged_path}}/xdg-user-data/share" },
+                                  writable_paths: [".local/share/icons/hicolor"], writable_base: :home
   end
 
   zap trash: [

--- a/Casks/jetbrains-gateway-linux.rb
+++ b/Casks/jetbrains-gateway-linux.rb
@@ -5,8 +5,7 @@ cask "jetbrains-gateway-linux" do
   sha256 arm64_linux:  "4b145192467e729641b56073a6275ccdd4f117b640479d43a6d1f2f74baabcda",
          x86_64_linux: "5a3d333acc54ab8d091dc3e635b069a4ddda3faf7dace84966df87cdc7b8fce3"
 
-  url "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-#{version}#{"-aarch64" if arch == "aarch64"}.tar.gz",
-      verified: "download.jetbrains.com/idea/gateway/"
+  url "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-#{version}#{"-aarch64" if arch == "aarch64"}.tar.gz"
   name "JetBrains Gateway"
   desc "Connect to remote development environments with JetBrains IDEs"
   homepage "https://www.jetbrains.com/remote-development/gateway/"
@@ -21,28 +20,28 @@ cask "jetbrains-gateway-linux" do
 
   depends_on linux: :any
 
-  binary "JetBrainsGateway-#{version}/bin/gateway.sh", target: "jetbrains-gateway"
+  binary "gateway/bin/gateway.sh", target: "jetbrains-gateway"
 
-  preflight do
-    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
-    FileUtils.mkdir_p "#{xdg_data}/applications"
-    FileUtils.mkdir_p "#{xdg_data}/icons/hicolor/128x128/apps"
+  preflight_steps do
+    # Normalise the versioned directory before referring to it in declarative steps.
+    move "JetBrainsGateway-*", "gateway", source_glob: true
+    mkdir_p ".local/share/applications", base: :home
+    mkdir_p ".local/share/icons/hicolor/128x128/apps", base: :home
   end
 
-  postflight do
-    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
+  postflight_steps do
+    if_path_exists "gateway/bin/gateway.png" do
+      copy "gateway/bin/gateway.png", ".local/share/icons/hicolor/128x128/apps/jetbrains-gateway.png",
+           target_base: :home
+    end
 
-    icon_source = "#{staged_path}/JetBrainsGateway-#{version}/bin/gateway.png"
-    icon_target = "#{xdg_data}/icons/hicolor/128x128/apps/jetbrains-gateway.png"
-    FileUtils.cp(icon_source, icon_target) if File.exist?(icon_source)
-
-    File.write("#{xdg_data}/applications/jetbrains-gateway.desktop", <<~EOS)
+    write_file ".local/share/applications/jetbrains-gateway.desktop", <<~EOS, base: :home
       [Desktop Entry]
       Name=JetBrains Gateway
       Comment=Connect to remote development environments with JetBrains IDEs
       GenericName=Remote Development Client
-      Exec=#{HOMEBREW_PREFIX}/bin/jetbrains-gateway
-      Icon=#{icon_target}
+      Exec={{HOMEBREW_PREFIX}}/bin/jetbrains-gateway
+      Icon=jetbrains-gateway
       Type=Application
       StartupNotify=true
       StartupWMClass=jetbrains-gateway
@@ -51,10 +50,9 @@ cask "jetbrains-gateway-linux" do
     EOS
   end
 
-  uninstall_postflight do
-    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
-    FileUtils.rm("#{xdg_data}/applications/jetbrains-gateway.desktop", force: true)
-    FileUtils.rm("#{xdg_data}/icons/hicolor/128x128/apps/jetbrains-gateway.png", force: true)
+  uninstall_postflight_steps do
+    remove ".local/share/applications/jetbrains-gateway.desktop", base: :home
+    remove ".local/share/icons/hicolor/128x128/apps/jetbrains-gateway.png", base: :home
   end
 
   zap trash: [

--- a/Casks/kiro-cli-linux.rb
+++ b/Casks/kiro-cli-linux.rb
@@ -6,8 +6,7 @@ cask "kiro-cli-linux" do
   sha256 arm64_linux:  "09f4ecb046a90e91854dba11f80d465571d9961d456305a597c202f6e1b03a53",
          x86_64_linux: "9f5e37230e7f3becbfe16663569a31dca0698004d8f5d0c575ac92812e0087c6"
 
-  url "https://prod.download.cli.kiro.dev/stable/#{version}/kirocli-#{arch}-linux.zip",
-      verified: "prod.download.cli.kiro.dev/"
+  url "https://prod.download.cli.kiro.dev/stable/#{version}/kirocli-#{arch}-linux.zip"
   name "Kiro CLI"
   desc "Amazon Q Developer CLI - AI-powered command-line assistant"
   homepage "https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-installing.html"
@@ -25,15 +24,14 @@ cask "kiro-cli-linux" do
   binary "kirocli/bin/kiro-cli-chat"
   binary "kirocli/bin/kiro-cli-term"
 
-  postflight do
+  postflight_steps do
     # Create `q` symlink for backward compatibility with Amazon Q CLI
-    q_link = "#{HOMEBREW_PREFIX}/bin/q"
-    FileUtils.rm(q_link, force: true)
-    FileUtils.ln_s "#{HOMEBREW_PREFIX}/bin/kiro-cli", q_link
+    symlink "bin/kiro-cli", "bin/q", source_base: :homebrew_prefix, target_base: :homebrew_prefix,
+            overwrite: true
   end
 
-  uninstall_postflight do
-    FileUtils.rm("#{HOMEBREW_PREFIX}/bin/q", force: true)
+  uninstall_postflight_steps do
+    remove "bin/q", base: :homebrew_prefix
   end
 
   zap trash: [

--- a/Casks/localwp-linux.rb
+++ b/Casks/localwp-linux.rb
@@ -30,31 +30,30 @@ cask "localwp-linux" do
 
   binary "opt/Local/local", target: "localwp"
 
-  preflight do
-    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
-    FileUtils.mkdir_p "#{xdg_data}/applications"
-    FileUtils.mkdir_p "#{xdg_data}/icons/hicolor/512x512/apps"
-
-    # Extract the deb package
-    deb_file = "#{staged_path}/local-#{version.csv.first}-linux.deb"
-    system "dpkg", "-x", deb_file, staged_path
-    FileUtils.rm(deb_file, force: true)
+  preflight_steps do
+    # Normalise the versioned deb filename, then extract with dpkg.
+    move "local-*-linux.deb", "local.deb", source_glob: true
+    run "{{HOMEBREW_PREFIX}}/opt/dpkg/bin/dpkg-deb",
+        args: ["-x", "{{staged_path}}/local.deb", "{{staged_path}}"]
+    remove "local.deb"
   end
 
-  postflight do
-    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
+  postflight_steps do
+    mkdir_p ".local/share/applications", base: :home
+    mkdir_p ".local/share/icons/hicolor/512x512/apps", base: :home
 
-    icon_source = "#{staged_path}/usr/share/icons/hicolor/512x512/apps/local.png"
-    icon_target = "#{xdg_data}/icons/hicolor/512x512/apps/localwp.png"
-    FileUtils.cp(icon_source, icon_target) if File.exist?(icon_source)
+    if_path_exists "usr/share/icons/hicolor/512x512/apps/local.png" do
+      copy "usr/share/icons/hicolor/512x512/apps/local.png",
+           ".local/share/icons/hicolor/512x512/apps/localwp.png", target_base: :home
+    end
 
-    File.write("#{xdg_data}/applications/localwp.desktop", <<~EOS)
+    write_file ".local/share/applications/localwp.desktop", <<~EOS, base: :home
       [Desktop Entry]
       Name=LocalWP
       Comment=Local WordPress development environment
       GenericName=WordPress Development Tool
-      Exec=#{HOMEBREW_PREFIX}/bin/localwp %U
-      Icon=#{icon_target}
+      Exec={{HOMEBREW_PREFIX}}/bin/localwp %U
+      Icon=localwp
       Type=Application
       StartupNotify=true
       StartupWMClass=Local
@@ -64,10 +63,9 @@ cask "localwp-linux" do
     EOS
   end
 
-  uninstall_postflight do
-    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
-    FileUtils.rm("#{xdg_data}/applications/localwp.desktop", force: true)
-    FileUtils.rm("#{xdg_data}/icons/hicolor/512x512/apps/localwp.png", force: true)
+  uninstall_postflight_steps do
+    remove ".local/share/applications/localwp.desktop", base: :home
+    remove ".local/share/icons/hicolor/512x512/apps/localwp.png", base: :home
   end
 
   zap trash: [

--- a/Casks/opencode-desktop-linux.rb
+++ b/Casks/opencode-desktop-linux.rb
@@ -5,8 +5,7 @@ cask "opencode-desktop-linux" do
   sha256 arm64_linux:  "eb20092a6c7153333b8454936e1fd699bd89782b580e4620bc70d4c2c9bf96ea",
          x86_64_linux: "19ab7bf4ca0e06519ca2f4a291e5a3814ad06aa72a66f6442ea79fd1a4d29f52"
 
-  url "https://github.com/anomalyco/opencode/releases/download/v#{version}/opencode-desktop-linux-#{arch}.rpm",
-      verified: "github.com/anomalyco/opencode/"
+  url "https://github.com/anomalyco/opencode/releases/download/v#{version}/opencode-desktop-linux-#{arch}.rpm"
   name "OpenCode"
   desc "Open source AI coding agent desktop client"
   homepage "https://opencode.ai/"
@@ -35,19 +34,23 @@ cask "opencode-desktop-linux" do
   artifact "usr/share/icons/hicolor/128x128/apps/ai.opencode.desktop.png",
            target: "#{Dir.home}/.local/share/icons/hicolor/128x128/apps/ai.opencode.desktop.png"
 
-  preflight do
-    rpm2cpio = Formula["rpm2cpio"].bin/"rpm2cpio"
-    cpio = Formula["cpio"].bin/"cpio"
-    system "sh", "-c", "'#{rpm2cpio}' '#{staged_path}/opencode-desktop-linux-#{arch}.rpm' | '#{cpio}' -idm --quiet",
-           chdir: staged_path
+  preflight_steps do
+    # Normalise the arch-specific RPM filename, then split extraction.
+    move "opencode-desktop-linux-*.rpm", "opencode-desktop.rpm", source_glob: true
+    run "{{HOMEBREW_PREFIX}}/bin/rpm2cpio", args:        ["{{staged_path}}/opencode-desktop.rpm"],
+                                            stdout_path: "opencode-desktop.cpio"
+    run "{{HOMEBREW_PREFIX}}/bin/cpio", args: ["-idm", "--quiet"], stdin_path: "opencode-desktop.cpio",
+        chdir: "{{staged_path}}"
+    remove ["opencode-desktop.rpm", "opencode-desktop.cpio"]
 
-    # Update desktop files to use Homebrew binary path
-    desktop_files = Dir["#{staged_path}/usr/share/applications/*.desktop"]
-    desktop_files.each do |desktop_file|
-      content = File.read(desktop_file)
-      content.gsub!(/^Exec=.*/, "Exec=#{HOMEBREW_PREFIX}/bin/opencode-desktop %U")
-      File.write(desktop_file, content)
-    end
+    # Rewrite every discovered desktop file, mirroring the original
+    # `Dir["#{staged_path}/usr/share/applications/*.desktop"].each` behaviour.
+    run "sh", args: ["-c", <<~SH]
+      for f in "{{staged_path}}"/usr/share/applications/*.desktop; do
+        [ -f "$f" ] || continue
+        sed -i 's#^Exec=.*#Exec={{HOMEBREW_PREFIX}}/bin/opencode-desktop %U#' "$f"
+      done
+    SH
   end
 
   zap trash: [

--- a/Casks/phpstorm-linux.rb
+++ b/Casks/phpstorm-linux.rb
@@ -28,22 +28,25 @@ cask "phpstorm-linux" do
   conflicts_with cask: "jetbrains-toolbox-linux"
   depends_on linux: :any
 
-  binary "#{HOMEBREW_PREFIX}/Caskroom/phpstorm-linux/#{version}/PhpStorm-#{version.csv.second}/bin/phpstorm"
+  binary "phpstorm/bin/phpstorm"
   artifact "jetbrains-phpstorm.desktop",
            target: "#{Dir.home}/.local/share/applications/jetbrains-phpstorm.desktop"
-  artifact "PhpStorm-#{version.csv.second}/bin/phpstorm.svg",
+  artifact "phpstorm/bin/phpstorm.svg",
            target: "#{Dir.home}/.local/share/icons/hicolor/scalable/apps/phpstorm.svg"
 
-  preflight do
-    File.write("#{staged_path}/PhpStorm-#{version.csv.second}/bin/phpstorm64.vmoptions", "-Dide.no.platform.update=true\n", mode: "a+")
-    FileUtils.mkdir_p("#{Dir.home}/.local/share/applications")
-    FileUtils.mkdir_p("#{Dir.home}/.local/share/icons/hicolor/scalable/apps")
-    File.write("#{staged_path}/jetbrains-phpstorm.desktop", <<~EOS)
+  preflight_steps do
+    # Normalise the versioned directory before referring to it in declarative steps.
+    move "PhpStorm-*", "phpstorm", source_glob: true
+    touch "phpstorm/bin/phpstorm64.vmoptions"
+    inreplace "phpstorm/bin/phpstorm64.vmoptions", /\z/, "-Dide.no.platform.update=true\n"
+    mkdir_p ".local/share/applications", base: :home
+    mkdir_p ".local/share/icons/hicolor/scalable/apps", base: :home
+    write_file "jetbrains-phpstorm.desktop", <<~EOS
       [Desktop Entry]
       Version=1.0
       Name=PhpStorm
       Comment=A smart IDE for PHP and Web
-      Exec=#{HOMEBREW_PREFIX}/bin/phpstorm %u
+      Exec={{HOMEBREW_PREFIX}}/bin/phpstorm %u
       Icon=phpstorm
       Type=Application
       Categories=Development;IDE;
@@ -54,8 +57,12 @@ cask "phpstorm-linux" do
     EOS
   end
 
-  postflight do
-    system "/usr/bin/xdg-icon-resource", "forceupdate"
+  postflight_steps do
+    mkdir_p "xdg-user-data"
+    symlink ".local/share", "xdg-user-data/share", source_base: :home
+    run "/usr/bin/xdg-icon-resource", args: ["forceupdate"], must_succeed: false,
+                                  env: { "XDG_DATA_HOME" => "{{staged_path}}/xdg-user-data/share" },
+                                  writable_paths: [".local/share/icons/hicolor"], writable_base: :home
   end
 
   zap trash: [

--- a/Casks/positron-linux.rb
+++ b/Casks/positron-linux.rb
@@ -5,8 +5,7 @@ cask "positron-linux" do
   sha256 arm64_linux:  "10765960b1aaba292685660f8efefe2387f56644afc88f50ea74495ef806064d",
          x86_64_linux: "0e694502bdb876b7eea962b6dae3d77c7bcf22ebd0aedab7625e61520718dcea"
 
-  url "https://cdn.posit.co/positron/releases/deb/#{(arch == "arm64") ? "arm64" : "x86_64"}/Positron-#{version}-#{arch}.deb",
-      verified: "cdn.posit.co/positron/"
+  url "https://cdn.posit.co/positron/releases/deb/#{(arch == "arm64") ? "arm64" : "x86_64"}/Positron-#{version}-#{arch}.deb"
   name "Positron"
   desc "Next-generation data science IDE for R and Python"
   homepage "https://positron.posit.co/"
@@ -24,38 +23,39 @@ cask "positron-linux" do
 
   binary "usr/bin/positron", target: "positron"
 
-  preflight do
-    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
-    FileUtils.mkdir_p "#{xdg_data}/applications"
-    FileUtils.mkdir_p "#{xdg_data}/icons/hicolor/256x256/apps"
-
-    # Extract the deb package
-    deb_file = "#{staged_path}/Positron-#{version}-#{arch}.deb"
-    system "dpkg", "-x", deb_file, staged_path
-    FileUtils.rm(deb_file, force: true)
+  preflight_steps do
+    # Normalise the arch- and version-specific deb filename, then extract.
+    move "Positron-{{version}}-*.deb", "positron.deb", source_glob: true
+    run "{{HOMEBREW_PREFIX}}/opt/dpkg/bin/dpkg-deb",
+        args: ["-x", "{{staged_path}}/positron.deb", "{{staged_path}}"]
+    remove "positron.deb"
   end
 
-  postflight do
-    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
+  postflight_steps do
+    mkdir_p ".local/share/applications", base: :home
+    mkdir_p ".local/share/icons/hicolor/256x256/apps", base: :home
 
-    icon_source = "#{staged_path}/usr/share/icons/hicolor/256x256/apps/positron.png"
-    icon_target = "#{xdg_data}/icons/hicolor/256x256/apps/positron.png"
-    FileUtils.cp(icon_source, icon_target) if File.exist?(icon_source)
+    if_path_exists "usr/share/icons/hicolor/256x256/apps/positron.png" do
+      copy "usr/share/icons/hicolor/256x256/apps/positron.png",
+           ".local/share/icons/hicolor/256x256/apps/positron.png", target_base: :home
+    end
 
-    desktop_source = "#{staged_path}/usr/share/applications/positron.desktop"
-    if File.exist?(desktop_source)
-      desktop_content = File.read(desktop_source)
-      desktop_content.gsub!(/^Exec=.*/, "Exec=#{HOMEBREW_PREFIX}/bin/positron %F")
-      desktop_content.gsub!(/^Icon=.*/, "Icon=#{icon_target}")
-      File.write("#{xdg_data}/applications/positron.desktop", desktop_content)
-    else
-      File.write("#{xdg_data}/applications/positron.desktop", <<~EOS)
+    if_path_exists "usr/share/applications/positron.desktop" do
+      copy "usr/share/applications/positron.desktop", ".local/share/applications/positron.desktop",
+           target_base: :home
+      inreplace ".local/share/applications/positron.desktop", /^Exec=.*/,
+                "Exec={{HOMEBREW_PREFIX}}/bin/positron %F", base: :home, audit_result: false
+      inreplace ".local/share/applications/positron.desktop", /^Icon=.*/,
+                "Icon=positron", base: :home, audit_result: false
+    end
+    unless_path_exists "usr/share/applications/positron.desktop" do
+      write_file ".local/share/applications/positron.desktop", <<~EOS, base: :home
         [Desktop Entry]
         Name=Positron
         Comment=Next-generation data science IDE for R and Python
         GenericName=Data Science IDE
-        Exec=#{HOMEBREW_PREFIX}/bin/positron %F
-        Icon=#{icon_target}
+        Exec={{HOMEBREW_PREFIX}}/bin/positron %F
+        Icon=positron
         Type=Application
         StartupNotify=true
         StartupWMClass=Positron
@@ -66,10 +66,9 @@ cask "positron-linux" do
     end
   end
 
-  uninstall_postflight do
-    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
-    FileUtils.rm("#{xdg_data}/applications/positron.desktop", force: true)
-    FileUtils.rm("#{xdg_data}/icons/hicolor/256x256/apps/positron.png", force: true)
+  uninstall_postflight_steps do
+    remove ".local/share/applications/positron.desktop", base: :home
+    remove ".local/share/icons/hicolor/256x256/apps/positron.png", base: :home
   end
 
   zap trash: [

--- a/Casks/proton-mail-bridge-linux.rb
+++ b/Casks/proton-mail-bridge-linux.rb
@@ -2,8 +2,7 @@ cask "proton-mail-bridge-linux" do
   version "3.26.0"
   sha256 "c076872522ce2f0facd0e64764d7d588b3a1ed213ff3acd25386b51e8a1f02e8"
 
-  url "https://github.com/ProtonMail/proton-bridge/releases/download/v#{version}/protonmail-bridge_#{version}-1_amd64.deb",
-      verified: "github.com/ProtonMail/proton-bridge/"
+  url "https://github.com/ProtonMail/proton-bridge/releases/download/v#{version}/protonmail-bridge_#{version}-1_amd64.deb"
   name "Proton Mail Bridge"
   desc "Integrate Proton Mail with email clients via local IMAP/SMTP"
   homepage "https://proton.me/mail/bridge"
@@ -17,38 +16,55 @@ cask "proton-mail-bridge-linux" do
 
   binary "usr/bin/proton-bridge", target: "proton-mail-bridge"
 
-  preflight do
-    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
-    FileUtils.mkdir_p "#{xdg_data}/applications"
-    FileUtils.mkdir_p "#{xdg_data}/icons/hicolor/256x256/apps"
-
-    # Extract the deb package
-    deb_file = "#{staged_path}/protonmail-bridge_#{version}-1_amd64.deb"
-    system "dpkg", "-x", deb_file, staged_path
-    FileUtils.rm(deb_file, force: true)
+  preflight_steps do
+    # Normalise the versioned deb filename, then extract.
+    move "protonmail-bridge_*-1_amd64.deb", "proton-mail-bridge.deb", source_glob: true
+    run "{{HOMEBREW_PREFIX}}/opt/dpkg/bin/dpkg-deb",
+        args: ["-x", "{{staged_path}}/proton-mail-bridge.deb", "{{staged_path}}"]
+    remove "proton-mail-bridge.deb"
   end
 
-  postflight do
-    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
+  postflight_steps do
+    mkdir_p ".local/share/applications", base: :home
+    mkdir_p ".local/share/icons/hicolor/256x256/apps", base: :home
 
-    icon_source = Dir.glob("#{staged_path}/usr/share/icons/**/*.png").min_by { |f| -File.size(f) }
-    icon_target = "#{xdg_data}/icons/hicolor/256x256/apps/proton-mail-bridge.png"
-    FileUtils.cp(icon_source, icon_target) if icon_source && File.exist?(icon_source)
+    # Select the largest icon and the first desktop file within staged_path first,
+    # mirroring the original `Dir.glob(...).min_by { -File.size }` / `.first` picks.
+    run "sh", args: ["-eu", "-c", <<~'SH']
+      staged="{{staged_path}}"
+      tab=$(printf '\t')
+      icon_src=$(find "$staged/usr/share/icons" -type f -name '*.png' -printf '%s\t%p\0' 2>/dev/null |
+        LC_ALL=C sort -z -t "$tab" -k1,1nr -k2,2 | head -z -n 1 | cut -z -f2-)
+      if [ -n "$icon_src" ] && [ -f "$icon_src" ]; then
+        cp "$icon_src" "$staged/proton-mail-bridge.icon.png"
+      fi
+      desktop_src=$(ls "$staged"/usr/share/applications/*.desktop 2>/dev/null | head -1)
+      if [ -n "$desktop_src" ] && [ -f "$desktop_src" ]; then
+        cp "$desktop_src" "$staged/proton-mail-bridge.desktop"
+      fi
+    SH
 
-    desktop_source = Dir.glob("#{staged_path}/usr/share/applications/*.desktop").first
-    if desktop_source && File.exist?(desktop_source)
-      desktop_content = File.read(desktop_source)
-      desktop_content.gsub!(/^Exec=.*/, "Exec=#{HOMEBREW_PREFIX}/bin/proton-mail-bridge %U")
-      desktop_content.gsub!(/^Icon=.*/, "Icon=#{icon_target}")
-      File.write("#{xdg_data}/applications/proton-mail-bridge.desktop", desktop_content)
-    else
-      File.write("#{xdg_data}/applications/proton-mail-bridge.desktop", <<~EOS)
+    if_path_exists "proton-mail-bridge.icon.png" do
+      copy "proton-mail-bridge.icon.png",
+           ".local/share/icons/hicolor/256x256/apps/proton-mail-bridge.png", target_base: :home
+    end
+
+    if_path_exists "proton-mail-bridge.desktop" do
+      copy "proton-mail-bridge.desktop", ".local/share/applications/proton-mail-bridge.desktop",
+           target_base: :home
+      inreplace ".local/share/applications/proton-mail-bridge.desktop", /^Exec=.*/,
+                "Exec={{HOMEBREW_PREFIX}}/bin/proton-mail-bridge %U", base: :home, audit_result: false
+      inreplace ".local/share/applications/proton-mail-bridge.desktop", /^Icon=.*/,
+                "Icon=proton-mail-bridge", base: :home, audit_result: false
+    end
+    unless_path_exists "proton-mail-bridge.desktop" do
+      write_file ".local/share/applications/proton-mail-bridge.desktop", <<~EOS, base: :home
         [Desktop Entry]
         Name=Proton Mail Bridge
         Comment=Integrate Proton Mail with email clients via local IMAP/SMTP
         GenericName=Mail Bridge
-        Exec=#{HOMEBREW_PREFIX}/bin/proton-mail-bridge %U
-        Icon=#{icon_target}
+        Exec={{HOMEBREW_PREFIX}}/bin/proton-mail-bridge %U
+        Icon=proton-mail-bridge
         Type=Application
         StartupNotify=true
         StartupWMClass=proton-bridge
@@ -58,10 +74,9 @@ cask "proton-mail-bridge-linux" do
     end
   end
 
-  uninstall_postflight do
-    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
-    FileUtils.rm("#{xdg_data}/applications/proton-mail-bridge.desktop", force: true)
-    FileUtils.rm("#{xdg_data}/icons/hicolor/256x256/apps/proton-mail-bridge.png", force: true)
+  uninstall_postflight_steps do
+    remove ".local/share/applications/proton-mail-bridge.desktop", base: :home
+    remove ".local/share/icons/hicolor/256x256/apps/proton-mail-bridge.png", base: :home
   end
 
   zap trash: [

--- a/Casks/pycharm-linux.rb
+++ b/Casks/pycharm-linux.rb
@@ -28,22 +28,25 @@ cask "pycharm-linux" do
   conflicts_with cask: "jetbrains-toolbox-linux"
   depends_on linux: :any
 
-  binary "#{HOMEBREW_PREFIX}/Caskroom/pycharm-linux/#{version}/pycharm-#{version.csv.first}/bin/pycharm"
+  binary "pycharm/bin/pycharm"
   artifact "jetbrains-pycharm.desktop",
            target: "#{Dir.home}/.local/share/applications/jetbrains-pycharm.desktop"
-  artifact "pycharm-#{version.csv.first}/bin/pycharm.svg",
+  artifact "pycharm/bin/pycharm.svg",
            target: "#{Dir.home}/.local/share/icons/hicolor/scalable/apps/pycharm.svg"
 
-  preflight do
-    File.write("#{staged_path}/pycharm-#{version.csv.first}/bin/pycharm64.vmoptions", "-Dide.no.platform.update=true\n", mode: "a+")
-    FileUtils.mkdir_p("#{Dir.home}/.local/share/applications")
-    FileUtils.mkdir_p("#{Dir.home}/.local/share/icons/hicolor/scalable/apps")
-    File.write("#{staged_path}/jetbrains-pycharm.desktop", <<~EOS)
+  preflight_steps do
+    # Normalise the versioned directory before referring to it in declarative steps.
+    move "pycharm-*", "pycharm", source_glob: true
+    touch "pycharm/bin/pycharm64.vmoptions"
+    inreplace "pycharm/bin/pycharm64.vmoptions", /\z/, "-Dide.no.platform.update=true\n"
+    mkdir_p ".local/share/applications", base: :home
+    mkdir_p ".local/share/icons/hicolor/scalable/apps", base: :home
+    write_file "jetbrains-pycharm.desktop", <<~EOS
       [Desktop Entry]
       Version=1.0
       Name=PyCharm
       Comment=The Only Python IDE you need
-      Exec=#{HOMEBREW_PREFIX}/bin/pycharm %u
+      Exec={{HOMEBREW_PREFIX}}/bin/pycharm %u
       Icon=pycharm
       Type=Application
       Categories=Development;IDE;
@@ -54,8 +57,12 @@ cask "pycharm-linux" do
     EOS
   end
 
-  postflight do
-    system "/usr/bin/xdg-icon-resource", "forceupdate"
+  postflight_steps do
+    mkdir_p "xdg-user-data"
+    symlink ".local/share", "xdg-user-data/share", source_base: :home
+    run "/usr/bin/xdg-icon-resource", args: ["forceupdate"], must_succeed: false,
+                                  env: { "XDG_DATA_HOME" => "{{staged_path}}/xdg-user-data/share" },
+                                  writable_paths: [".local/share/icons/hicolor"], writable_base: :home
   end
 
   zap trash: [

--- a/Casks/rancher-desktop-linux.rb
+++ b/Casks/rancher-desktop-linux.rb
@@ -11,41 +11,36 @@ cask "rancher-desktop-linux" do
 
   binary "squashfs-root/AppRun", target: "rancher-desktop"
 
-  preflight do
-    # Extract AppImage contents
-    appimage_path = "#{staged_path}/rancher-desktop-latest-x86_64.AppImage"
-    system "chmod", "+x", appimage_path
-    system appimage_path, "--appimage-extract", chdir: staged_path
-
-    # Remove the original AppImage to save space
-    FileUtils.rm appimage_path
+  preflight_steps do
+    # Normalise the AppImage filename before extraction.
+    move "rancher-desktop-latest-x86_64.AppImage", "rancher-desktop.AppImage"
+    set_permissions "rancher-desktop.AppImage", "+x"
+    run "rancher-desktop.AppImage", args: ["--appimage-extract"], base: :staged_path, chdir: "{{staged_path}}"
+    remove "rancher-desktop.AppImage"
   end
 
-  postflight do
-    # Create necessary directories
-    FileUtils.mkdir_p "#{Dir.home}/.local/share/applications"
-    FileUtils.mkdir_p "#{Dir.home}/.local/share/icons/hicolor/512x512/apps"
+  postflight_steps do
+    mkdir_p ".local/share/applications", base: :home
+    mkdir_p ".local/share/icons/hicolor/512x512/apps", base: :home
 
-    # Copy icon
-    icon_source = "#{staged_path}/squashfs-root/rancher-desktop.png"
-    icon_target = "#{Dir.home}/.local/share/icons/hicolor/512x512/apps/rancher-desktop.png"
-    FileUtils.cp(icon_source, icon_target) if File.exist?(icon_source)
+    if_path_exists "squashfs-root/rancher-desktop.png" do
+      copy "squashfs-root/rancher-desktop.png", ".local/share/icons/hicolor/512x512/apps/rancher-desktop.png",
+           target_base: :home
+    end
 
-    # Update and copy desktop entry
-    desktop_source = "#{staged_path}/squashfs-root/rancher-desktop.desktop"
-    desktop_target = "#{Dir.home}/.local/share/applications/rancher-desktop.desktop"
-    if File.exist?(desktop_source)
-      desktop_content = File.read(desktop_source)
-      desktop_content.gsub!(/^Exec=.*/, "Exec=#{HOMEBREW_PREFIX}/bin/rancher-desktop")
-      desktop_content.gsub!(/^Icon=.*/, "Icon=#{icon_target}")
-      File.write(desktop_target, desktop_content)
+    if_path_exists "squashfs-root/rancher-desktop.desktop" do
+      copy "squashfs-root/rancher-desktop.desktop", ".local/share/applications/rancher-desktop.desktop",
+           target_base: :home
+      inreplace ".local/share/applications/rancher-desktop.desktop", /^Exec=.*/,
+                "Exec={{HOMEBREW_PREFIX}}/bin/rancher-desktop", base: :home, audit_result: false
+      inreplace ".local/share/applications/rancher-desktop.desktop", /^Icon=.*/, "Icon=rancher-desktop",
+                base: :home, audit_result: false
     end
   end
 
-  uninstall_postflight do
-    # Clean up icon and desktop files
-    FileUtils.rm("#{Dir.home}/.local/share/icons/hicolor/512x512/apps/rancher-desktop.png")
-    FileUtils.rm("#{Dir.home}/.local/share/applications/rancher-desktop.desktop")
+  uninstall_postflight_steps do
+    remove ".local/share/icons/hicolor/512x512/apps/rancher-desktop.png", base: :home
+    remove ".local/share/applications/rancher-desktop.desktop", base: :home
   end
 
   zap trash: [

--- a/Casks/rider-linux.rb
+++ b/Casks/rider-linux.rb
@@ -28,22 +28,25 @@ cask "rider-linux" do
   conflicts_with cask: "jetbrains-toolbox-linux"
   depends_on linux: :any
 
-  binary "#{HOMEBREW_PREFIX}/Caskroom/rider-linux/#{version}/JetBrains Rider-#{version.csv.first}/bin/rider"
+  binary "rider/bin/rider"
   artifact "jetbrains-rider.desktop",
            target: "#{Dir.home}/.local/share/applications/jetbrains-rider.desktop"
-  artifact "JetBrains Rider-#{version.csv.first}/bin/rider.svg",
+  artifact "rider/bin/rider.svg",
            target: "#{Dir.home}/.local/share/icons/hicolor/scalable/apps/rider.svg"
 
-  preflight do
-    File.write("#{staged_path}/JetBrains Rider-#{version.csv.first}/bin/rider64.vmoptions", "-Dide.no.platform.update=true\n", mode: "a+")
-    FileUtils.mkdir_p("#{Dir.home}/.local/share/applications")
-    FileUtils.mkdir_p("#{Dir.home}/.local/share/icons/hicolor/scalable/apps")
-    File.write("#{staged_path}/jetbrains-rider.desktop", <<~EOS)
+  preflight_steps do
+    # Normalise the versioned directory before referring to it in declarative steps.
+    move "JetBrains Rider-*", "rider", source_glob: true
+    touch "rider/bin/rider64.vmoptions"
+    inreplace "rider/bin/rider64.vmoptions", /\z/, "-Dide.no.platform.update=true\n"
+    mkdir_p ".local/share/applications", base: :home
+    mkdir_p ".local/share/icons/hicolor/scalable/apps", base: :home
+    write_file "jetbrains-rider.desktop", <<~EOS
       [Desktop Entry]
       Version=1.0
       Name=Rider
       Comment=All-in-one IDE for .NET and game development
-      Exec=#{HOMEBREW_PREFIX}/bin/rider %u
+      Exec={{HOMEBREW_PREFIX}}/bin/rider %u
       Icon=rider
       Type=Application
       Categories=Development;IDE;
@@ -54,8 +57,12 @@ cask "rider-linux" do
     EOS
   end
 
-  postflight do
-    system "/usr/bin/xdg-icon-resource", "forceupdate"
+  postflight_steps do
+    mkdir_p "xdg-user-data"
+    symlink ".local/share", "xdg-user-data/share", source_base: :home
+    run "/usr/bin/xdg-icon-resource", args: ["forceupdate"], must_succeed: false,
+                                  env: { "XDG_DATA_HOME" => "{{staged_path}}/xdg-user-data/share" },
+                                  writable_paths: [".local/share/icons/hicolor"], writable_base: :home
   end
 
   zap trash: [

--- a/Casks/rubymine-linux.rb
+++ b/Casks/rubymine-linux.rb
@@ -28,22 +28,25 @@ cask "rubymine-linux" do
   conflicts_with cask: "jetbrains-toolbox-linux"
   depends_on linux: :any
 
-  binary "#{HOMEBREW_PREFIX}/Caskroom/rubymine-linux/#{version}/RubyMine-#{version.csv.first}/bin/rubymine"
+  binary "rubymine/bin/rubymine"
   artifact "jetbrains-rubymine.desktop",
            target: "#{Dir.home}/.local/share/applications/jetbrains-rubymine.desktop"
-  artifact "RubyMine-#{version.csv.first}/bin/rubymine.svg",
+  artifact "rubymine/bin/rubymine.svg",
            target: "#{Dir.home}/.local/share/icons/hicolor/scalable/apps/rubymine.svg"
 
-  preflight do
-    File.write("#{staged_path}/RubyMine-#{version.csv.first}/bin/rubymine64.vmoptions", "-Dide.no.platform.update=true\n", mode: "a+")
-    FileUtils.mkdir_p("#{Dir.home}/.local/share/applications")
-    FileUtils.mkdir_p("#{Dir.home}/.local/share/icons/hicolor/scalable/apps")
-    File.write("#{staged_path}/jetbrains-rubymine.desktop", <<~EOS)
+  preflight_steps do
+    # Normalise the versioned directory before referring to it in declarative steps.
+    move "RubyMine-*", "rubymine", source_glob: true
+    touch "rubymine/bin/rubymine64.vmoptions"
+    inreplace "rubymine/bin/rubymine64.vmoptions", /\z/, "-Dide.no.platform.update=true\n"
+    mkdir_p ".local/share/applications", base: :home
+    mkdir_p ".local/share/icons/hicolor/scalable/apps", base: :home
+    write_file "jetbrains-rubymine.desktop", <<~EOS
       [Desktop Entry]
       Version=1.0
       Name=RubyMine
       Comment=A Ruby and Rails IDE
-      Exec=#{HOMEBREW_PREFIX}/bin/rubymine %u
+      Exec={{HOMEBREW_PREFIX}}/bin/rubymine %u
       Icon=rubymine
       Type=Application
       Categories=Development;IDE;
@@ -54,8 +57,12 @@ cask "rubymine-linux" do
     EOS
   end
 
-  postflight do
-    system "/usr/bin/xdg-icon-resource", "forceupdate"
+  postflight_steps do
+    mkdir_p "xdg-user-data"
+    symlink ".local/share", "xdg-user-data/share", source_base: :home
+    run "/usr/bin/xdg-icon-resource", args: ["forceupdate"], must_succeed: false,
+                                  env: { "XDG_DATA_HOME" => "{{staged_path}}/xdg-user-data/share" },
+                                  writable_paths: [".local/share/icons/hicolor"], writable_base: :home
   end
 
   zap trash: [

--- a/Casks/rustrover-linux.rb
+++ b/Casks/rustrover-linux.rb
@@ -28,22 +28,25 @@ cask "rustrover-linux" do
   conflicts_with cask: "jetbrains-toolbox-linux"
   depends_on linux: :any
 
-  binary "#{HOMEBREW_PREFIX}/Caskroom/rustrover-linux/#{version}/RustRover-#{version.csv.first}/bin/rustrover"
+  binary "rustrover/bin/rustrover"
   artifact "jetbrains-rustrover.desktop",
            target: "#{Dir.home}/.local/share/applications/jetbrains-rustrover.desktop"
-  artifact "RustRover-#{version.csv.first}/bin/rustrover.svg",
+  artifact "rustrover/bin/rustrover.svg",
            target: "#{Dir.home}/.local/share/icons/hicolor/scalable/apps/rustrover.svg"
 
-  preflight do
-    File.write("#{staged_path}/RustRover-#{version.csv.first}/bin/rustrover64.vmoptions", "-Dide.no.platform.update=true\n", mode: "a+")
-    FileUtils.mkdir_p("#{Dir.home}/.local/share/applications")
-    FileUtils.mkdir_p("#{Dir.home}/.local/share/icons/hicolor/scalable/apps")
-    File.write("#{staged_path}/jetbrains-rustrover.desktop", <<~EOS)
+  preflight_steps do
+    # Normalise the versioned directory before referring to it in declarative steps.
+    move "RustRover-*", "rustrover", source_glob: true
+    touch "rustrover/bin/rustrover64.vmoptions"
+    inreplace "rustrover/bin/rustrover64.vmoptions", /\z/, "-Dide.no.platform.update=true\n"
+    mkdir_p ".local/share/applications", base: :home
+    mkdir_p ".local/share/icons/hicolor/scalable/apps", base: :home
+    write_file "jetbrains-rustrover.desktop", <<~EOS
       [Desktop Entry]
       Version=1.0
       Name=RustRover
       Comment=A powerful IDE for Rust
-      Exec=#{HOMEBREW_PREFIX}/bin/rustrover %u
+      Exec={{HOMEBREW_PREFIX}}/bin/rustrover %u
       Icon=rustrover
       Type=Application
       Categories=Development;IDE;
@@ -54,8 +57,12 @@ cask "rustrover-linux" do
     EOS
   end
 
-  postflight do
-    system "/usr/bin/xdg-icon-resource", "forceupdate"
+  postflight_steps do
+    mkdir_p "xdg-user-data"
+    symlink ".local/share", "xdg-user-data/share", source_base: :home
+    run "/usr/bin/xdg-icon-resource", args: ["forceupdate"], must_succeed: false,
+                                  env: { "XDG_DATA_HOME" => "{{staged_path}}/xdg-user-data/share" },
+                                  writable_paths: [".local/share/icons/hicolor"], writable_base: :home
   end
 
   zap trash: [

--- a/Casks/tableplus-linux.rb
+++ b/Casks/tableplus-linux.rb
@@ -2,8 +2,7 @@ cask "tableplus-linux" do
   version "0.1.308"
   sha256 "b2a880fa2099aea1cf224876e097a3b5f06f20bb59b771cdd9b29fff549cef5e"
 
-  url "https://deb.tableplus.com/debian/22/pool/main/t/tableplus/tableplus_#{version}_amd64.deb",
-      verified: "deb.tableplus.com/"
+  url "https://deb.tableplus.com/debian/22/pool/main/t/tableplus/tableplus_#{version}_amd64.deb"
   name "TablePlus"
   desc "Modern, native database GUI client supporting multiple databases"
   homepage "https://tableplus.com/"
@@ -22,38 +21,54 @@ cask "tableplus-linux" do
 
   binary "usr/bin/tableplus", target: "tableplus"
 
-  preflight do
-    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
-    FileUtils.mkdir_p "#{xdg_data}/applications"
-    FileUtils.mkdir_p "#{xdg_data}/icons/hicolor/256x256/apps"
-
-    # Extract the deb package
-    deb_file = "#{staged_path}/tableplus_#{version}_amd64.deb"
-    system "dpkg", "-x", deb_file, staged_path
-    FileUtils.rm(deb_file, force: true)
+  preflight_steps do
+    # Normalise the versioned deb filename, then extract.
+    move "tableplus_*_amd64.deb", "tableplus.deb", source_glob: true
+    run "{{HOMEBREW_PREFIX}}/opt/dpkg/bin/dpkg-deb",
+        args: ["-x", "{{staged_path}}/tableplus.deb", "{{staged_path}}"]
+    remove "tableplus.deb"
   end
 
-  postflight do
-    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
+  postflight_steps do
+    mkdir_p ".local/share/applications", base: :home
+    mkdir_p ".local/share/icons/hicolor/256x256/apps", base: :home
 
-    icon_source = Dir.glob("#{staged_path}/usr/share/icons/**/*.png").min_by { |f| -File.size(f) }
-    icon_target = "#{xdg_data}/icons/hicolor/256x256/apps/tableplus.png"
-    FileUtils.cp(icon_source, icon_target) if icon_source && File.exist?(icon_source)
+    # Select the largest icon and the first desktop file within staged_path first,
+    # mirroring the original `Dir.glob(...).min_by { -File.size }` / `.first` picks.
+    run "sh", args: ["-eu", "-c", <<~'SH']
+      staged="{{staged_path}}"
+      tab=$(printf '\t')
+      icon_src=$(find "$staged/usr/share/icons" -type f -name '*.png' -printf '%s\t%p\0' 2>/dev/null |
+        LC_ALL=C sort -z -t "$tab" -k1,1nr -k2,2 | head -z -n 1 | cut -z -f2-)
+      if [ -n "$icon_src" ] && [ -f "$icon_src" ]; then
+        cp "$icon_src" "$staged/tableplus.icon.png"
+      fi
+      desktop_src=$(ls "$staged"/usr/share/applications/*.desktop 2>/dev/null | head -1)
+      if [ -n "$desktop_src" ] && [ -f "$desktop_src" ]; then
+        cp "$desktop_src" "$staged/tableplus.desktop"
+      fi
+    SH
 
-    desktop_source = Dir.glob("#{staged_path}/usr/share/applications/*.desktop").first
-    if desktop_source && File.exist?(desktop_source)
-      desktop_content = File.read(desktop_source)
-      desktop_content.gsub!(/^Exec=.*/, "Exec=#{HOMEBREW_PREFIX}/bin/tableplus %U")
-      desktop_content.gsub!(/^Icon=.*/, "Icon=#{icon_target}")
-      File.write("#{xdg_data}/applications/tableplus.desktop", desktop_content)
-    else
-      File.write("#{xdg_data}/applications/tableplus.desktop", <<~EOS)
+    if_path_exists "tableplus.icon.png" do
+      copy "tableplus.icon.png", ".local/share/icons/hicolor/256x256/apps/tableplus.png",
+           target_base: :home
+    end
+
+    if_path_exists "tableplus.desktop" do
+      copy "tableplus.desktop", ".local/share/applications/tableplus.desktop", target_base: :home
+      inreplace ".local/share/applications/tableplus.desktop", /^Exec=.*/,
+                "Exec={{HOMEBREW_PREFIX}}/bin/tableplus %U", base: :home, audit_result: false
+      inreplace ".local/share/applications/tableplus.desktop", /^Icon=.*/,
+                "Icon=tableplus", base: :home, audit_result: false
+    end
+    unless_path_exists "tableplus.desktop" do
+      write_file ".local/share/applications/tableplus.desktop", <<~EOS, base: :home
         [Desktop Entry]
         Name=TablePlus
         Comment=Modern, native database GUI client
         GenericName=Database GUI
-        Exec=#{HOMEBREW_PREFIX}/bin/tableplus %U
-        Icon=#{icon_target}
+        Exec={{HOMEBREW_PREFIX}}/bin/tableplus %U
+        Icon=tableplus
         Type=Application
         StartupNotify=true
         StartupWMClass=TablePlus
@@ -64,10 +79,9 @@ cask "tableplus-linux" do
     end
   end
 
-  uninstall_postflight do
-    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
-    FileUtils.rm("#{xdg_data}/applications/tableplus.desktop", force: true)
-    FileUtils.rm("#{xdg_data}/icons/hicolor/256x256/apps/tableplus.png", force: true)
+  uninstall_postflight_steps do
+    remove ".local/share/applications/tableplus.desktop", base: :home
+    remove ".local/share/icons/hicolor/256x256/apps/tableplus.png", base: :home
   end
 
   zap trash: [

--- a/Casks/thorium-linux.rb
+++ b/Casks/thorium-linux.rb
@@ -3,8 +3,7 @@ cask "thorium-linux" do
   sha256 "b17cd482a67d968a6b04239b1d72d18e45b5e44cc514c05baaaab1b90f992230"
 
   # Uses the AVX2 build (recommended for modern CPUs manufactured after ~2013)
-  url "https://github.com/Alex313031/thorium/releases/download/M#{version}/Thorium_Browser_#{version}_AVX2.AppImage",
-      verified: "github.com/Alex313031/thorium/"
+  url "https://github.com/Alex313031/thorium/releases/download/M#{version}/Thorium_Browser_#{version}_AVX2.AppImage"
   name "Thorium Browser"
   desc "Fast, privacy-hardened Chromium browser with compiler optimizations"
   homepage "https://thorium.rocks/"
@@ -24,36 +23,40 @@ cask "thorium-linux" do
 
   binary "squashfs-root/thorium-browser", target: "thorium-browser"
 
-  preflight do
-    appimage_path = "#{staged_path}/Thorium_Browser_#{version}_AVX2.AppImage"
-    system "chmod", "+x", appimage_path
-    system appimage_path, "--appimage-extract", chdir: staged_path
-    FileUtils.rm appimage_path
+  preflight_steps do
+    # Normalise the versioned AppImage filename before extraction.
+    move "Thorium_Browser_*.AppImage", "thorium-browser.AppImage", source_glob: true
+    set_permissions "thorium-browser.AppImage", "+x"
+    run "thorium-browser.AppImage", args: ["--appimage-extract"], base: :staged_path,
+        chdir: "{{staged_path}}"
+    remove "thorium-browser.AppImage"
   end
 
-  postflight do
-    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
-    FileUtils.mkdir_p "#{xdg_data}/applications"
-    FileUtils.mkdir_p "#{xdg_data}/icons/hicolor/256x256/apps"
+  postflight_steps do
+    mkdir_p ".local/share/applications", base: :home
+    mkdir_p ".local/share/icons/hicolor/256x256/apps", base: :home
 
-    icon_source = "#{staged_path}/squashfs-root/product_logo_256.png"
-    icon_target = "#{xdg_data}/icons/hicolor/256x256/apps/thorium-browser.png"
-    FileUtils.cp(icon_source, icon_target) if File.exist?(icon_source)
+    if_path_exists "squashfs-root/product_logo_256.png" do
+      copy "squashfs-root/product_logo_256.png",
+           ".local/share/icons/hicolor/256x256/apps/thorium-browser.png", target_base: :home
+    end
 
-    desktop_source = "#{staged_path}/squashfs-root/thorium-browser.desktop"
-    if File.exist?(desktop_source)
-      desktop_content = File.read(desktop_source)
-      desktop_content.gsub!(/^Exec=thorium-browser/, "Exec=#{HOMEBREW_PREFIX}/bin/thorium-browser")
-      desktop_content.gsub!(/^Icon=.*/, "Icon=#{icon_target}")
-      File.write("#{xdg_data}/applications/thorium-browser.desktop", desktop_content)
-    else
-      File.write("#{xdg_data}/applications/thorium-browser.desktop", <<~EOS)
+    if_path_exists "squashfs-root/thorium-browser.desktop" do
+      copy "squashfs-root/thorium-browser.desktop", ".local/share/applications/thorium-browser.desktop",
+           target_base: :home
+      inreplace ".local/share/applications/thorium-browser.desktop", /^Exec=thorium-browser/,
+                "Exec={{HOMEBREW_PREFIX}}/bin/thorium-browser", base: :home, audit_result: false
+      inreplace ".local/share/applications/thorium-browser.desktop", /^Icon=.*/,
+                "Icon=thorium-browser", base: :home, audit_result: false
+    end
+    unless_path_exists "squashfs-root/thorium-browser.desktop" do
+      write_file ".local/share/applications/thorium-browser.desktop", <<~EOS, base: :home
         [Desktop Entry]
         Name=Thorium Browser
         Comment=Fast, privacy-hardened Chromium browser
         GenericName=Web Browser
-        Exec=#{HOMEBREW_PREFIX}/bin/thorium-browser %U
-        Icon=#{icon_target}
+        Exec={{HOMEBREW_PREFIX}}/bin/thorium-browser %U
+        Icon=thorium-browser
         Type=Application
         StartupNotify=true
         StartupWMClass=thorium-browser
@@ -64,10 +67,9 @@ cask "thorium-linux" do
     end
   end
 
-  uninstall_postflight do
-    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
-    FileUtils.rm("#{xdg_data}/applications/thorium-browser.desktop", force: true)
-    FileUtils.rm("#{xdg_data}/icons/hicolor/256x256/apps/thorium-browser.png", force: true)
+  uninstall_postflight_steps do
+    remove ".local/share/applications/thorium-browser.desktop", base: :home
+    remove ".local/share/icons/hicolor/256x256/apps/thorium-browser.png", base: :home
   end
 
   zap trash: [

--- a/Casks/webex-linux.rb
+++ b/Casks/webex-linux.rb
@@ -2,8 +2,7 @@ cask "webex-linux" do
   version "46.8.0.35631"
   sha256 :no_check
 
-  url "https://binaries.webex.com/WebexDesktop-CentOS-Official-Package/Webex.rpm",
-      verified: "binaries.webex.com/WebexDesktop-CentOS-Official-Package/"
+  url "https://binaries.webex.com/WebexDesktop-CentOS-Official-Package/Webex.rpm"
   name "Webex"
   desc "Calling, messaging, and meeting app by Cisco"
   homepage "https://www.webex.com/downloads.html"
@@ -23,43 +22,52 @@ cask "webex-linux" do
 
   binary "opt/Webex/bin/CiscoCollabHost", target: "webex"
   artifact "opt/Webex/bin/sparklogosmall.png",
-           target: "#{Dir.home}/.local/share/pixmaps/webex.png"
+           target: "#{Dir.home}/.local/share/icons/webex.png"
   artifact "opt/Webex/bin/webex.desktop",
            target: "#{Dir.home}/.local/share/applications/webex.desktop"
 
-  preflight do
-    rpm_path = staged_path/"Webex.rpm"
-    rpm2cpio = Formula["rpm2cpio"].bin/"rpm2cpio"
-    cpio = Formula["cpio"].bin/"cpio"
-    system "sh", "-c", "'#{rpm2cpio}' '#{rpm_path}' | '#{cpio}' -idm --quiet", chdir: staged_path
-    FileUtils.rm rpm_path
+  preflight_steps do
+    run "{{HOMEBREW_PREFIX}}/bin/rpm2cpio", args:        ["{{staged_path}}/Webex.rpm"],
+                                            stdout_path: "webex.cpio"
+    run "{{HOMEBREW_PREFIX}}/bin/cpio", args: ["-idm", "--quiet"], stdin_path: "webex.cpio",
+        chdir: "{{staged_path}}"
+    remove "Webex.rpm"
+    remove "webex.cpio"
 
-    FileUtils.touch staged_path/"opt/Webex/bin/rpm.dat"
+    touch "opt/Webex/bin/rpm.dat"
+    remove "opt/Webex/lib/libstdc++.so.6"
 
-    FileUtils.rm staged_path/"opt/Webex/lib/libstdc++.so.6", force: true
-
-    desktop_file = staged_path/"opt/Webex/bin/webex.desktop"
-    content = File.read(desktop_file)
-    content.gsub!(/^Exec=.*/, "Exec=#{HOMEBREW_PREFIX}/bin/webex %U")
-    content.gsub!(/^Icon=.*/, "Icon=#{Dir.home}/.local/share/pixmaps/webex.png")
-    File.write(desktop_file, content)
+    inreplace "opt/Webex/bin/webex.desktop", /^Exec=.*/,
+              "Exec={{HOMEBREW_PREFIX}}/bin/webex %U", audit_result: false
+    inreplace "opt/Webex/bin/webex.desktop", /^Icon=.*/, "Icon=webex", audit_result: false
   end
 
-  postflight do
-    system "xdg-mime", "default", "webex.desktop",
-           "x-scheme-handler/webexteams",
-           "x-scheme-handler/ciscospark",
-           "x-scheme-handler/webex"
+  postflight_steps do
+    # Give xdg-mime a stable HOME whose .config directory is a narrow handle
+    # onto the real user's configuration directory.
+    mkdir_p ".config", base: :home
+    mkdir_p "webex-home"
+    symlink ".config", "webex-home/.config", source_base: :home
+    run "xdg-mime",
+        args: ["default", "webex.desktop", "x-scheme-handler/webexteams",
+               "x-scheme-handler/ciscospark", "x-scheme-handler/webex"],
+        env: {
+          "HOME"            => "{{staged_path}}/webex-home",
+          "XDG_CONFIG_HOME" => "{{staged_path}}/webex-home/.config",
+        },
+        must_succeed: false, writable_paths: [".config"], writable_base: :home
 
-    webex_wrapper = HOMEBREW_PREFIX/"bin/webex"
-    if webex_wrapper.exist?
-      libxcrypt_lib = Formula["libxcrypt-compat"].lib
-      content = File.read(webex_wrapper)
-      unless content.include?(libxcrypt_lib.to_s)
-        content.gsub!(/^exec /, "export LD_LIBRARY_PATH=\"#{libxcrypt_lib}:$LD_LIBRARY_PATH\"\nexec ")
-        File.write(webex_wrapper, content)
-      end
-    end
+    # The binary artifact created `{{HOMEBREW_PREFIX}}/bin/webex` as a symlink to
+    # the staged CiscoCollabHost, so modifying the staged file is equivalent. Keep
+    # the idempotent marker guard exactly as the original (insert only when absent).
+    run "sh",
+        args: ["-c", <<~SH]
+          wrapper="{{staged_path}}/opt/Webex/bin/CiscoCollabHost"
+          marker="{{HOMEBREW_PREFIX}}/opt/libxcrypt-compat/lib"
+          if [ -f "$wrapper" ] && ! grep -qF "$marker" "$wrapper"; then
+            sed -i 's#^exec #export LD_LIBRARY_PATH="'"$marker"':$LD_LIBRARY_PATH"\\nexec #' "$wrapper"
+          fi
+        SH
   end
 
   zap trash: [

--- a/Casks/webstorm-linux.rb
+++ b/Casks/webstorm-linux.rb
@@ -28,22 +28,25 @@ cask "webstorm-linux" do
   conflicts_with cask: "jetbrains-toolbox-linux"
   depends_on linux: :any
 
-  binary "#{HOMEBREW_PREFIX}/Caskroom/webstorm-linux/#{version}/WebStorm-#{version.csv.second}/bin/webstorm"
+  binary "webstorm/bin/webstorm"
   artifact "jetbrains-webstorm.desktop",
            target: "#{Dir.home}/.local/share/applications/jetbrains-webstorm.desktop"
-  artifact "WebStorm-#{version.csv.second}/bin/webstorm.svg",
+  artifact "webstorm/bin/webstorm.svg",
            target: "#{Dir.home}/.local/share/icons/hicolor/scalable/apps/webstorm.svg"
 
-  preflight do
-    File.write("#{staged_path}/WebStorm-#{version.csv.second}/bin/webstorm64.vmoptions", "-Dide.no.platform.update=true\n", mode: "a+")
-    FileUtils.mkdir_p("#{Dir.home}/.local/share/applications")
-    FileUtils.mkdir_p("#{Dir.home}/.local/share/icons/hicolor/scalable/apps")
-    File.write("#{staged_path}/jetbrains-webstorm.desktop", <<~EOS)
+  preflight_steps do
+    # Normalise the versioned directory before referring to it in declarative steps.
+    move "WebStorm-*", "webstorm", source_glob: true
+    touch "webstorm/bin/webstorm64.vmoptions"
+    inreplace "webstorm/bin/webstorm64.vmoptions", /\z/, "-Dide.no.platform.update=true\n"
+    mkdir_p ".local/share/applications", base: :home
+    mkdir_p ".local/share/icons/hicolor/scalable/apps", base: :home
+    write_file "jetbrains-webstorm.desktop", <<~EOS
       [Desktop Entry]
       Version=1.0
       Name=WebStorm
       Comment=A JavaScript and TypeScript IDE
-      Exec=#{HOMEBREW_PREFIX}/bin/webstorm %u
+      Exec={{HOMEBREW_PREFIX}}/bin/webstorm %u
       Icon=webstorm
       Type=Application
       Categories=Development;IDE;
@@ -54,8 +57,12 @@ cask "webstorm-linux" do
     EOS
   end
 
-  postflight do
-    system "/usr/bin/xdg-icon-resource", "forceupdate"
+  postflight_steps do
+    mkdir_p "xdg-user-data"
+    symlink ".local/share", "xdg-user-data/share", source_base: :home
+    run "/usr/bin/xdg-icon-resource", args: ["forceupdate"], must_succeed: false,
+                                  env: { "XDG_DATA_HOME" => "{{staged_path}}/xdg-user-data/share" },
+                                  writable_paths: [".local/share/icons/hicolor"], writable_base: :home
   end
 
   zap trash: [

--- a/Casks/winboat.rb
+++ b/Casks/winboat.rb
@@ -17,32 +17,27 @@ cask "winboat" do
 
   binary "winboat-#{version}-x64/winboat"
 
-  preflight do
-    require "open-uri"
-
-    FileUtils.mkdir_p "#{Dir.home}/.local/share/applications"
-    FileUtils.mkdir_p "#{Dir.home}/.local/share/icons/hicolor/512x512/apps"
-
-    # Download icon from GitHub repo
-    icon_url = "https://raw.githubusercontent.com/TibixDev/winboat/main/src/renderer/public/img/winboat_logo.png"
-    icon_path = "#{Dir.home}/.local/share/icons/hicolor/512x512/apps/winboat.png"
-
-    URI.parse(icon_url).open do |remote_file|
-      File.binwrite(icon_path, remote_file.read)
-    end
-
-    desktop_file = <<~EOS
+  preflight_steps do
+    # Download the icon into staged_path, then install it and the desktop entry
+    # under the user's data home. `open-uri` is replaced by an explicit curl with
+    # `network_access: true`, preserving fail-fast download semantics.
+    run "curl",
+        args: [
+          "--fail", "--location", "--silent", "--show-error", "--output", "winboat.png",
+          "https://raw.githubusercontent.com/TibixDev/winboat/main/src/renderer/public/img/winboat_logo.png"
+        ],
+        chdir: "{{staged_path}}", network_access: true
+    copy "winboat.png", ".local/share/icons/hicolor/512x512/apps/winboat.png", target_base: :home
+    write_file ".local/share/applications/winboat.desktop", <<~EOS, base: :home
       [Desktop Entry]
       Name=Winboat
       Comment=Run Windows apps on Linux with seamless integration
-      Exec=#{HOMEBREW_PREFIX}/bin/winboat %U
+      Exec={{HOMEBREW_PREFIX}}/bin/winboat %U
       Terminal=false
       Type=Application
       Icon=winboat
       Categories=Utility;
     EOS
-
-    File.write("#{Dir.home}/.local/share/applications/winboat.desktop", desktop_file)
   end
 
   zap trash: [

--- a/Casks/windsurf-linux.rb
+++ b/Casks/windsurf-linux.rb
@@ -2,8 +2,7 @@ cask "windsurf-linux" do
   version "3.4.27,0d4bf12ed4a7597cb8ae9016fe8474468aad98a2"
   sha256 "80850124b31331f63c24a201d1317bdacdfb438fb2bcc9b31c9b7a6391391619"
 
-  url "https://windsurf-stable.codeiumdata.com/linux-x64/stable/#{version.csv.second}/Devin-linux-x64-#{version.csv.first}.tar.gz",
-      verified: "windsurf-stable.codeiumdata.com/"
+  url "https://windsurf-stable.codeiumdata.com/linux-x64/stable/#{version.csv.second}/Devin-linux-x64-#{version.csv.first}.tar.gz"
   name "Windsurf (Devin)"
   desc "AI-powered IDE from Codeium/Cognition, formerly Windsurf Editor"
   homepage "https://windsurf.com/"
@@ -15,29 +14,39 @@ cask "windsurf-linux" do
     end
   end
 
-  binary "Devin-linux-x64-#{version.csv.first}/windsurf", target: "windsurf"
+  binary "windsurf/windsurf", target: "windsurf"
 
-  preflight do
-    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
-    FileUtils.mkdir_p "#{xdg_data}/applications"
-    FileUtils.mkdir_p "#{xdg_data}/icons/hicolor/512x512/apps"
+  preflight_steps do
+    # Normalise the versioned app directory before referring to it below.
+    move "Devin-linux-x64-*", "windsurf", source_glob: true
+    mkdir_p ".local/share/applications", base: :home
+    mkdir_p ".local/share/icons/hicolor/512x512/apps", base: :home
   end
 
-  postflight do
-    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
-    app_dir = "#{staged_path}/Devin-linux-x64-#{version.csv.first}"
+  postflight_steps do
+    # Select the largest icon within the app dir, mirroring the original
+    # `Dir.glob(...).min_by { -File.size }` pick.
+    run "sh", args: ["-eu", "-c", <<~'SH']
+      staged="{{staged_path}}"
+      tab=$(printf '\t')
+      icon_src=$(find "$staged/windsurf" -type f -name '*.png' -printf '%s\t%p\0' 2>/dev/null |
+        LC_ALL=C sort -z -t "$tab" -k1,1nr -k2,2 | head -z -n 1 | cut -z -f2-)
+      if [ -n "$icon_src" ] && [ -f "$icon_src" ]; then
+        cp "$icon_src" "$staged/windsurf.icon.png"
+      fi
+    SH
 
-    icon_source = Dir.glob("#{app_dir}/**/*.png").min_by { |f| -File.size(f) }
-    icon_target = "#{xdg_data}/icons/hicolor/512x512/apps/windsurf.png"
-    FileUtils.cp(icon_source, icon_target) if icon_source && File.exist?(icon_source)
+    if_path_exists "windsurf.icon.png" do
+      copy "windsurf.icon.png", ".local/share/icons/hicolor/512x512/apps/windsurf.png", target_base: :home
+    end
 
-    File.write("#{xdg_data}/applications/windsurf.desktop", <<~EOS)
+    write_file ".local/share/applications/windsurf.desktop", <<~EOS, base: :home
       [Desktop Entry]
       Name=Windsurf
       Comment=AI-powered IDE from Codeium/Cognition
       GenericName=Text Editor
-      Exec=#{HOMEBREW_PREFIX}/bin/windsurf %F
-      Icon=#{icon_target}
+      Exec={{HOMEBREW_PREFIX}}/bin/windsurf %F
+      Icon=windsurf
       Type=Application
       StartupNotify=false
       StartupWMClass=Windsurf
@@ -48,15 +57,14 @@ cask "windsurf-linux" do
 
       [Desktop Action new-empty-window]
       Name=New Empty Window
-      Exec=#{HOMEBREW_PREFIX}/bin/windsurf --new-window %F
-      Icon=#{icon_target}
+      Exec={{HOMEBREW_PREFIX}}/bin/windsurf --new-window %F
+      Icon=windsurf
     EOS
   end
 
-  uninstall_postflight do
-    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
-    FileUtils.rm("#{xdg_data}/applications/windsurf.desktop", force: true)
-    FileUtils.rm("#{xdg_data}/icons/hicolor/512x512/apps/windsurf.png", force: true)
+  uninstall_postflight_steps do
+    remove ".local/share/applications/windsurf.desktop", base: :home
+    remove ".local/share/icons/hicolor/512x512/apps/windsurf.png", base: :home
   end
 
   zap trash: [

--- a/Casks/zed-linux@preview.rb
+++ b/Casks/zed-linux@preview.rb
@@ -16,27 +16,27 @@ cask "zed-linux@preview" do
 
   binary "zed-preview.app/bin/zed", target: "zed-preview"
 
-  preflight do
-    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
-    FileUtils.mkdir_p "#{xdg_data}/applications"
-    FileUtils.mkdir_p "#{xdg_data}/icons"
+  preflight_steps do
+    mkdir_p ".local/share/applications", base: :home
+    mkdir_p ".local/share/icons", base: :home
   end
 
-  postflight do
-    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
-    desktop_content = File.read("#{staged_path}/zed-preview.app/share/applications/dev.zed.Zed-Preview.desktop")
-    desktop_content.gsub!(/^TryExec=.*/, "TryExec=#{HOMEBREW_PREFIX}/bin/zed-preview")
-    desktop_content.gsub!(/^Exec=zed/, "Exec=#{HOMEBREW_PREFIX}/bin/zed-preview")
-    desktop_content.gsub!(/^Icon=.*/, "Icon=zed-preview")
-    File.write("#{xdg_data}/applications/dev.zed.Zed-Preview.desktop", desktop_content)
-    FileUtils.cp("#{staged_path}/zed-preview.app/share/icons/hicolor/512x512/apps/zed.png",
-                 "#{xdg_data}/icons/zed-preview.png")
+  postflight_steps do
+    copy "zed-preview.app/share/applications/dev.zed.Zed-Preview.desktop",
+         ".local/share/applications/dev.zed.Zed-Preview.desktop", target_base: :home
+    inreplace ".local/share/applications/dev.zed.Zed-Preview.desktop", /^TryExec=.*/,
+              "TryExec={{HOMEBREW_PREFIX}}/bin/zed-preview", base: :home, audit_result: false
+    inreplace ".local/share/applications/dev.zed.Zed-Preview.desktop", /^Exec=zed/,
+              "Exec={{HOMEBREW_PREFIX}}/bin/zed-preview", base: :home, audit_result: false
+    inreplace ".local/share/applications/dev.zed.Zed-Preview.desktop", /^Icon=.*/, "Icon=zed-preview",
+              base: :home, audit_result: false
+    copy "zed-preview.app/share/icons/hicolor/512x512/apps/zed.png", ".local/share/icons/zed-preview.png",
+         target_base: :home
   end
 
-  uninstall_postflight do
-    xdg_data = ENV.fetch("XDG_DATA_HOME", "#{Dir.home}/.local/share")
-    FileUtils.rm("#{xdg_data}/applications/dev.zed.Zed-Preview.desktop")
-    FileUtils.rm("#{xdg_data}/icons/zed-preview.png")
+  uninstall_postflight_steps do
+    remove ".local/share/applications/dev.zed.Zed-Preview.desktop", base: :home
+    remove ".local/share/icons/zed-preview.png", base: :home
   end
 
   zap trash: [

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ brew "<formula>"
 - **Subject to change** - Packages can be modified, moved, or deleted at any time
 - **Not for production** - Do not use for critical workflows
 
+## Linux desktop compatibility
+
+Migrated Linux desktop and icon integrations use `~/.local/share` rather than a custom `XDG_DATA_HOME`.
+Docker context setup uses `~/.docker`, and Webex MIME registration uses `~/.config`, rather than custom
+`DOCKER_CONFIG` or `XDG_CONFIG_HOME` values.
+
 ## Documentation
 
 `brew help`, `man brew` or check [Homebrew's documentation](https://docs.brew.sh).


### PR DESCRIPTION
## Summary

Current Homebrew deprecates the Ruby flight hooks and `verified:` URL parameter used by this tap. This migrates the affected Linux casks to the supported install-step DSL and incorporates the removals proposed in #623.

1. **Migrate 35 casks.** Replace deprecated installation and removal hooks with supported steps for launchers, desktop entries, icons, and application-specific setup.
2. **Document directory compatibility changes.** Desktop integration uses `~/.local/share`, Docker context setup uses `~/.docker`, and Webex MIME registration uses `~/.config` rather than custom environment overrides.
3. **Fix Emacs staging.** Remove the sandbox-created placeholder before moving the extracted payload so installation completes.
4. **Stop labeling cask bumps for bottle publishing.** Apply `pr-pull` only when formula changes are present. Cask bumps retain the existing squash-merge path. No new tests or CI jobs are added.

Verified: Local `brew test-bot` tap-syntax checks, cross-platform parsing, style checks, and migration fixtures passed. Emacs installed and uninstalled successfully on Linux x86_64, and `emacsclient` ran. Emacs itself could not launch because its upstream binary requires `libxml2.so.2`, which this machine lacks. Other casks were not individually installed, and GUI behavior remains unverified.

Related: #623
